### PR TITLE
Fix help message for unzip directory.

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStep/help-dir.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStep/help-dir.html
@@ -23,6 +23,6 @@
   -->
 
 <p>
-    The path of the base directory to create the zip from.
-    Leave empty to create from the current working directory.
+    The path of the base directory to extract the zip to.
+    Leave empty to extract in the current working directory.
 </p>


### PR DESCRIPTION
The help message for unzip directory appears to have been copied from zip directory.