### PR TITLE
[JENKINS-34927] Close streams of extracted files

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStepExecution.java
@@ -35,7 +35,6 @@ import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepEx
 import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 
 import javax.inject.Inject;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -143,19 +142,23 @@ public class UnZipStepExecution extends AbstractSynchronousNonBlockingStepExecut
                             logger.print(entry.getName());
                             logger.print(" -> ");
                             logger.println(f.getRemote());
-                            try (OutputStream outputStream = f.write()) {
-                                IOUtils.copy(zip.getInputStream(entry), outputStream);
+
+                            /*
+                            It is not by all means required to close the input streams of the zip file because they are
+                            closed once the zip file is closed. How ever doing so allows the zip class to reuse the
+                            Inflater instance that is used.
+                             */
+                            try (InputStream inputStream = zip.getInputStream(entry);
+                                 OutputStream outputStream = f.write()) {
+                                IOUtils.copy(inputStream, outputStream);
                                 outputStream.flush();
                             }
                         } else {
                             logger.print("Reading: ");
                             logger.println(entry.getName());
-                            // we need to copy byte by byte everything to be sure that no carriage return characters are skipped
-                            // readLine skips the carriage return and for example files ending with only one carriage return are trimmed
 
-                            try (InputStream is = zip.getInputStream(entry); ByteArrayOutputStream output = new ByteArrayOutputStream()) {
-                                IOUtils.copyLarge(is, output);
-                                strMap.put(entry.getName(), new String(output.toByteArray(), Charset.defaultCharset()));
+                            try (InputStream is = zip.getInputStream(entry)) {
+                                strMap.put(entry.getName(), IOUtils.toString(is, Charset.defaultCharset()));
                             }
                         }
                     }
@@ -166,9 +169,7 @@ public class UnZipStepExecution extends AbstractSynchronousNonBlockingStepExecut
                     return null;
                 }
             } finally {
-                if (zip != null) {
-                    zip.close(); //according to docs this should also close all open input streams.
-                }
+                IOUtils.closeQuietly(zip);
             }
         }
 

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStepExecution.java
@@ -39,6 +39,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.charset.Charset;
 import java.util.Enumeration;
@@ -142,7 +143,10 @@ public class UnZipStepExecution extends AbstractSynchronousNonBlockingStepExecut
                             logger.print(entry.getName());
                             logger.print(" -> ");
                             logger.println(f.getRemote());
-                            IOUtils.copy(zip.getInputStream(entry), f.write());
+                            try (OutputStream outputStream = f.write()) {
+                                IOUtils.copy(zip.getInputStream(entry), outputStream);
+                                outputStream.flush();
+                            }
                         } else {
                             logger.print("Reading: ");
                             logger.println(entry.getName());


### PR DESCRIPTION
I fixed the issue I created in JIRA by closing the output streams of the files extracted by the zip file. This resolves the issues I had with the plugin.

As the second commit I did some improvements to the general unzipping code regarding the load generated on the GC. Closing the input streams for the zip entries is not required by all means, because they are closed once the zip file closes. How ever closing the streams means that the parent zip class is able to reuse the Inflater objects that are rather expensive to create.

Also I replaced some of the code with the the counter part from `IOUtils` just to clean it up a little.

If you want to merge both my pull requests, you can also just pull in my master branch. I already resolve the merge conflict there.