### PR TITLE
Add repo.jenkins-ci.org to pluginRepositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,13 @@
         </repository>
     </repositories>
 
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Otherwise you might get errors like
"Plugin org.jenkins-ci.tools:maven-hpi-plugin:1.112 or one of its dependencies could not be resolved"
