### PR TITLE
[JENKINS-34122] Exclude output file from itself

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepExecution.java
@@ -90,7 +90,7 @@ public class ZipStepExecution extends AbstractSynchronousNonBlockingStepExecutio
             listener.getLogger().println("Writing zip file of " + source.getRemote()
                     + " filtered by [" + step.getGlob() + "] to " + destination.getRemote());
         }
-        int count = source.act(new ZipItFileCallable(destination, step.getGlob()));
+        int count = source.act(new ZipItFileCallable(destination, step.getGlob(), step.getZipFile()));
         listener.getLogger().println("Zipped " + count + " entries.");
         if (step.isArchive()) {
             listener.getLogger().println("Archiving " + destination.getRemote());
@@ -112,16 +112,19 @@ public class ZipStepExecution extends AbstractSynchronousNonBlockingStepExecutio
     static class ZipItFileCallable extends MasterToSlaveFileCallable<Integer> {
         final FilePath zipFile;
         final String glob;
+        private final String zipFileName;
 
-        public ZipItFileCallable(FilePath zipFile, String glob) {
+        public ZipItFileCallable(FilePath zipFile, String glob, String zipFileName) {
             this.zipFile = zipFile;
             this.glob = StringUtils.isBlank(glob) ? "**/*" : glob;
+            this.zipFileName = zipFileName;
         }
 
         @Override
         public Integer invoke(File dir, VirtualChannel channel) throws IOException, InterruptedException {
             Archiver archiver = ArchiverFactory.ZIP.create(zipFile.write());
             FileSet fs = Util.createFileSet(dir, glob);
+            fs.setExcludes(zipFileName);
             DirectoryScanner scanner = fs.getDirectoryScanner(new org.apache.tools.ant.Project());
             try {
                 for (String path : scanner.getIncludedFiles()) {

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepTest.java
@@ -42,10 +42,7 @@ import java.util.Scanner;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * Tests for {@link ZipStep}.
@@ -89,6 +86,21 @@ public class ZipStepTest {
         j.assertLogContains("Archiving", run);
         verifyArchivedHello(run, "");
 
+    }
+
+    @Test
+    public void shouldNotPutOutputArchiveIntoItself() throws Exception {
+
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+            "node {" +
+                "  writeFile file: 'hello.txt', text: 'Hello world'\n" +
+                "  zip zipFile: 'output.zip', dir: '', glob: '', archive: true\n" +
+                "}", false));
+        WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        j.assertLogContains("Writing zip file", run);
+        verifyArchivedNotContainingItself(run);
     }
 
     @Test
@@ -152,5 +164,15 @@ public class ZipStepTest {
         assertEquals("Hello World!", scanner.nextLine());
         assertNull("There should be no more entries", zip.getNextEntry());
         zip.close();
+    }
+
+    private void verifyArchivedNotContainingItself(WorkflowRun run) throws IOException {
+        assertTrue("Build should have artifacts", run.getHasArtifacts());
+        Run<WorkflowJob, WorkflowRun>.Artifact artifact = run.getArtifacts().get(0);
+        VirtualFile file = run.getArtifactManager().root().child(artifact.relativePath);
+        ZipInputStream zip = new ZipInputStream(file.open());
+        for(ZipEntry entry = zip.getNextEntry(); entry != null; entry = zip.getNextEntry()) {
+            assertNotEquals("The zip output file shouldn't contain itself", entry.getName(), artifact.getFileName());
+        }
     }
 }


### PR DESCRIPTION
[JENKINS-34122](https://issues.jenkins-ci.org/browse/JENKINS-34122) Using configured value from the step, rather than the `FilePath` to exclude is from the `FileSet`

@reviewbybees 