### PR TITLE
[JENKINS-34122] Exclude output file from itself

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepExecution.java
@@ -90,7 +90,7 @@ public class ZipStepExecution extends AbstractSynchronousNonBlockingStepExecutio
             listener.getLogger().println("Writing zip file of " + source.getRemote()
                     + " filtered by [" + step.getGlob() + "] to " + destination.getRemote());
         }
-        int count = source.act(new ZipItFileCallable(destination, step.getGlob()));
+        int count = source.act(new ZipItFileCallable(destination, step.getGlob(), step.getZipFile()));
         listener.getLogger().println("Zipped " + count + " entries.");
         if (step.isArchive()) {
             listener.getLogger().println("Archiving " + destination.getRemote());
@@ -112,16 +112,19 @@ public class ZipStepExecution extends AbstractSynchronousNonBlockingStepExecutio
     static class ZipItFileCallable extends MasterToSlaveFileCallable<Integer> {
         final FilePath zipFile;
         final String glob;
+        private final String zipFileName;
 
-        public ZipItFileCallable(FilePath zipFile, String glob) {
+        public ZipItFileCallable(FilePath zipFile, String glob, String zipFileName) {
             this.zipFile = zipFile;
             this.glob = StringUtils.isBlank(glob) ? "**/*" : glob;
+            this.zipFileName = zipFileName;
         }
 
         @Override
         public Integer invoke(File dir, VirtualChannel channel) throws IOException, InterruptedException {
             Archiver archiver = ArchiverFactory.ZIP.create(zipFile.write());
             FileSet fs = Util.createFileSet(dir, glob);
+            fs.setExcludes(zipFileName);
             DirectoryScanner scanner = fs.getDirectoryScanner(new org.apache.tools.ant.Project());
             try {
                 for (String path : scanner.getIncludedFiles()) {

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepTest.java
@@ -68,7 +68,7 @@ public class ReadPropertiesStepTest {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
                 "node('slaves') {\n" +
-                        "  def props = readProperties file: '" + file.getAbsolutePath() + "'\n" +
+                        "  def props = readProperties file: '" + file.getAbsolutePath().replace('\\', '/') + "'\n" +
                         "  assert props['test'] == 'One'\n" +
                         "  assert props['another'] == 'Two'\n" +
                         "  assert props.test == 'One'\n" +
@@ -91,7 +91,7 @@ public class ReadPropertiesStepTest {
         p.setDefinition(new CpsFlowDefinition(
                 "node('slaves') {\n" +
                         "  def d = [test: 'Default', something: 'Default']\n" +
-                        "  def props = readProperties defaults: d, file: '" + file.getAbsolutePath() + "'\n" +
+                        "  def props = readProperties defaults: d, file: '" + file.getAbsolutePath().replace('\\', '/') + "'\n" +
                         "  assert props['test'] == 'One'\n" +
                         "  assert props['another'] == 'Two'\n" +
                         "  assert props.test == 'One'\n" +
@@ -115,7 +115,7 @@ public class ReadPropertiesStepTest {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
                 "node('slaves') {\n" +
-                        "  String propsText = readFile file: '" + file.getAbsolutePath() + "'\n" +
+                        "  String propsText = readFile file: '" + file.getAbsolutePath().replace('\\', '/') + "'\n" +
                         "  def props = readProperties text: propsText\n" +
                         "  assert props['test'] == 'One'\n" +
                         "  assert props['another'] == 'Two'\n" +
@@ -170,8 +170,8 @@ public class ReadPropertiesStepTest {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
                 "node('slaves') {\n" +
-                        "  String propsText = readFile file: '" + textFile.getAbsolutePath() + "'\n" +
-                        "  def props = readProperties text: propsText, file: '" + file.getAbsolutePath() + "'\n" +
+                        "  String propsText = readFile file: '" + textFile.getAbsolutePath().replace('\\', '/') + "'\n" +
+                        "  def props = readProperties text: propsText, file: '" + file.getAbsolutePath().replace('\\', '/') + "'\n" +
                         "  assert props['test'] == 'One'\n" +
                         "  assert props.test == 'One'\n" +
                         "  assert props['text'] == 'TextOne'\n" +

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/mf/ReadManifestStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/mf/ReadManifestStepTest.java
@@ -70,7 +70,7 @@ public class ReadManifestStepTest {
     public void testJarWithGradleManifest() throws Exception {
         URL resource = getClass().getResource("gradle-manifest.war");
 
-        String remoting = new File(resource.getPath()).getAbsolutePath();
+        String remoting = new File(resource.getPath()).getAbsolutePath().replace('\\', '/');
         p.setDefinition(new CpsFlowDefinition(
                 "node('slaves') {\n" +
                         "  def man = readManifest file: '" + remoting + "'\n" +
@@ -86,7 +86,7 @@ public class ReadManifestStepTest {
 
     @Test
     public void testJar() throws Exception {
-        String remoting = new File(j.getWebAppRoot(), "WEB-INF/remoting.jar").getAbsolutePath();
+        String remoting = new File(j.getWebAppRoot(), "WEB-INF/remoting.jar").getAbsolutePath().replace('\\', '/');
         p.setDefinition(new CpsFlowDefinition(
                 "node('slaves') {\n" +
                         "  def man = readManifest file: '" + remoting + "'\n" +
@@ -106,9 +106,10 @@ public class ReadManifestStepTest {
     @Test
     public void testText() throws Exception {
         URL resource = getClass().getResource("testmanifest.mf");
+        File f = new File(resource.toURI());
         p.setDefinition(new CpsFlowDefinition(
                 "node('slaves') {\n" +
-                        "  String txt = readFile '"+resource.getPath()+"'\n" +
+                        "  String txt = readFile '"+f.getPath().replace('\\', '/')+"'\n" +
                         "  def man = readManifest text: txt\n" +
                         "  assert man != null\n" +
                         "  assert man.main != null\n" +
@@ -126,9 +127,10 @@ public class ReadManifestStepTest {
     @Test
     public void testFile() throws Exception {
         URL resource = getClass().getResource("testmanifest.mf");
+        File f = new File(resource.toURI());
         p.setDefinition(new CpsFlowDefinition(
                 "node('slaves') {\n" +
-                        "  def man = readManifest file: '"+resource.getPath()+"'\n" +
+                        "  def man = readManifest file: '"+f.getPath().replace('\\', '/')+"'\n" +
                         "  assert man != null\n" +
                         "  assert man.main != null\n" +
                         "  echo man.main['Version']\n" +

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FindFilesStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FindFilesStepTest.java
@@ -81,7 +81,7 @@ public class FindFilesStepTest {
                 "def files = findFiles()\n" +
                         "echo \"${files.length} files\"\n" +
                         "for(int i = 0; i < files.length; i++) {\n" +
-                        "  echo \"F: ${files[i]}\"\n" +
+                        "  echo \"F: ${files[i].path.replace('\\\\', '/')}\"\n" +
                         "}"
         );
         p.setDefinition(new CpsFlowDefinition(flow, false));
@@ -101,7 +101,7 @@ public class FindFilesStepTest {
                 "def files = findFiles(glob: '**/*.txt')\n" +
                         "echo \"${files.length} files\"\n" +
                         "for(int i = 0; i < files.length; i++) {\n" +
-                        "  echo \"F: ${files[i]}\"\n" +
+                        "  echo \"F: ${files[i].path.replace('\\\\', '/')}\"\n" +
                         "}"
         );
         p.setDefinition(new CpsFlowDefinition(flow, false));
@@ -128,7 +128,7 @@ public class FindFilesStepTest {
                 "def files = findFiles(glob: '**/a/*.txt')\n" +
                         "echo \"${files.length} files\"\n" +
                         "for(int i = 0; i < files.length; i++) {\n" +
-                        "  echo \"F: ${files[i]}\"\n" +
+                        "  echo \"F: ${files[i].path.replace('\\\\', '/')}\"\n" +
                         "}"
         );
         p.setDefinition(new CpsFlowDefinition(flow, false));

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepTest.java
@@ -104,6 +104,44 @@ public class ZipStepTest {
     }
 
     @Test
+    public void canArchiveFileWithSameName() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node {\n" + 
+                "  dir ('src') {\n" +
+                "   writeFile file: 'hello.txt', text: 'Hello world'\n" +
+                "   writeFile file: 'output.zip', text: 'not really a zip'\n" +
+                "  }\n" +
+                "  dir ('out') {\n" +
+                "    zip zipFile: 'output.zip', dir: '../src', glob: '', archive: true\n" +
+                "  }\n" +
+                "}\n",
+                false));
+        WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+
+        j.assertLogContains("Writing zip file", run);
+        assertTrue("Build should have artifacts", run.getHasArtifacts());
+        Run<WorkflowJob, WorkflowRun>.Artifact artifact = run.getArtifacts().get(0);
+        assertEquals("output.zip", artifact.getFileName());
+        VirtualFile file = run.getArtifactManager().root().child(artifact.relativePath);
+        ZipInputStream zip = new ZipInputStream(file.open());
+        ZipEntry entry = zip.getNextEntry();
+        while (entry != null && !entry.getName().equals("output.zip")) {
+            System.out.println("zip entry name is: " + entry.getName());
+            entry = zip.getNextEntry();
+        }
+        assertNotNull("output.zip should be included in the zip", entry);
+        // we should have the the zip - but double check
+        assertEquals("output.zip", entry.getName());
+        Scanner scanner = new Scanner(zip);
+        assertTrue(scanner.hasNextLine());
+        // the file that was not a zip should be included.
+        assertEquals("not really a zip", scanner.nextLine());
+        zip.close();
+    }
+
+    @Test
     public void globbedArchivedZip() throws Exception {
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepTest.java
@@ -42,10 +42,7 @@ import java.util.Scanner;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * Tests for {@link ZipStep}.
@@ -89,6 +86,21 @@ public class ZipStepTest {
         j.assertLogContains("Archiving", run);
         verifyArchivedHello(run, "");
 
+    }
+
+    @Test
+    public void shouldNotPutOutputArchiveIntoItself() throws Exception {
+
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+            "node {" +
+                "  writeFile file: 'hello.txt', text: 'Hello world'\n" +
+                "  zip zipFile: 'output.zip', dir: '', glob: '', archive: true\n" +
+                "}", false));
+        WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        j.assertLogContains("Writing zip file", run);
+        verifyArchivedNotContainingItself(run);
     }
 
     @Test
@@ -152,5 +164,15 @@ public class ZipStepTest {
         assertEquals("Hello World!", scanner.nextLine());
         assertNull("There should be no more entries", zip.getNextEntry());
         zip.close();
+    }
+
+    private void verifyArchivedNotContainingItself(WorkflowRun run) throws IOException {
+        assertTrue("Build should have artifacts", run.getHasArtifacts());
+        Run<WorkflowJob, WorkflowRun>.Artifact artifact = run.getArtifacts().get(0);
+        VirtualFile file = run.getArtifactManager().root().child(artifact.relativePath);
+        ZipInputStream zip = new ZipInputStream(file.open());
+        for(ZipEntry entry = zip.getNextEntry(); entry != null; entry = zip.getNextEntry()) {
+            assertNotEquals("The zip output file shouldn't contain itself", entry.getName(), artifact.getFileName());
+        }
     }
 }


### PR DESCRIPTION
[JENKINS-34122](https://issues.jenkins-ci.org/browse/JENKINS-34122) Using configured value from the step, rather than the `FilePath` to exclude is from the `FileSet`

This also fixes the unit tests so that they pass when run on windows.

@reviewbybees 
obsoletes #18, and satisfies my commitment to a better fix without introducing the regression I identified.  
