### PR TITLE
Adding try-block to avoid locking on Windows systems

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
@@ -64,7 +64,9 @@ public class ReadPropertiesStepExecution extends AbstractSynchronousNonBlockingS
         if (!StringUtils.isBlank(step.getFile())) {
             FilePath f = ws.child(step.getFile());
             if (f.exists() && !f.isDirectory()) {
-                properties.load(f.read());
+                try(InputStream is = f.read()){
+                   properties.load(is); 
+                }
             } else if (f.isDirectory()) {
                 logger.print("warning: ");
                 logger.print(f.getRemote());


### PR DESCRIPTION
After using readProperties on Windows, the file was still locked and could not be deleted until a restart of Jenkins. A try-block around the InputStream is preventing this.