### PR TITLE
JENKINS-43568: readProperties java.exe locks properties file

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
@@ -31,6 +31,8 @@ import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepEx
 import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 
 import javax.inject.Inject;
+
+import java.io.InputStream;
 import java.io.PrintStream;
 import java.io.StringReader;
 import java.util.HashMap;
@@ -64,7 +66,9 @@ public class ReadPropertiesStepExecution extends AbstractSynchronousNonBlockingS
         if (!StringUtils.isBlank(step.getFile())) {
             FilePath f = ws.child(step.getFile());
             if (f.exists() && !f.isDirectory()) {
-                properties.load(f.read());
+                try (InputStream is = f.read()) {
+                    properties.load(is);
+                }
             } else if (f.isDirectory()) {
                 logger.print("warning: ");
                 logger.print(f.getRemote());

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/mf/ReadManifestStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/mf/ReadManifestStepExecution.java
@@ -37,6 +37,7 @@ import javax.inject.Inject;
 import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Map;
 import java.util.jar.Manifest;
 
@@ -96,8 +97,10 @@ public class ReadManifestStepExecution extends AbstractSynchronousNonBlockingSte
                 return parseText(text);
             }
         } else {
-            Manifest manifest = new Manifest(path.read());
-            return new SimpleManifest(manifest);
+            try (InputStream is = path.read()) {
+                Manifest manifest = new Manifest(is);
+                return new SimpleManifest(manifest);
+            }
         }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/maven/ReadMavenPomStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/maven/ReadMavenPomStep.java
@@ -43,6 +43,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import java.io.FileNotFoundException;
+import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -123,7 +124,9 @@ public class ReadMavenPomStep extends AbstractStepImpl {
             if (path.isDirectory()) {
                 throw new FileNotFoundException(path.getRemote() + " is a directory.");
             }
-            return new MavenXpp3Reader().read(path.read());
+            try (InputStream is = path.read()) {
+                return new MavenXpp3Reader().read(is);
+            }
         }
     }
 


### PR DESCRIPTION
adding try-with-resource blocks to FilePath#read calls

The opened InputStreams now get closed automatically and do not leak file handles anymore