### PR TITLE
Don't require workspace for reading from text parameter.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/AbstractFileOrTextStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/AbstractFileOrTextStep.java
@@ -1,0 +1,48 @@
+package org.jenkinsci.plugins.pipeline.utility.steps;
+
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.kohsuke.stapler.DataBoundSetter;
+
+public class AbstractFileOrTextStep extends AbstractStepImpl {
+    protected String file;
+    protected String text;
+
+    /**
+     * The path to a file in the workspace to read from.
+     *
+     * @return the path
+     */
+    public String getFile() {
+        return file;
+    }
+
+    /**
+     * The path to a file in the workspace to read from.
+     *
+     * @param file the path
+     */
+    @DataBoundSetter
+    public void setFile(String file) {
+        this.file = file;
+    }
+
+    /**
+     * A String containing the formatted data.
+     *
+     * @return text to parse
+     */
+    public String getText() {
+        return text;
+    }
+
+    /**
+     * A String containing the formatted data.
+     *
+     * @param text text to parse
+     */
+    @DataBoundSetter
+    public void setText(String text) {
+        this.text = text;
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/AbstractFileOrTextStepDescriptorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/AbstractFileOrTextStepDescriptorImpl.java
@@ -1,0 +1,26 @@
+package org.jenkinsci.plugins.pipeline.utility.steps;
+
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.structs.DescribableHelper;
+
+import java.util.Map;
+
+import static org.apache.commons.lang.StringUtils.isBlank;
+
+public abstract class AbstractFileOrTextStepDescriptorImpl extends AbstractStepDescriptorImpl {
+    private final Class<? extends AbstractFileOrTextStep> stepType;
+
+    public AbstractFileOrTextStepDescriptorImpl(Class<? extends AbstractFileOrTextStep> stepType, Class<? extends AbstractFileOrTextStepExecution> executionType) {
+        super(executionType);
+        this.stepType = stepType;
+    }
+
+    @Override
+    public AbstractFileOrTextStep newInstance(Map<String, Object> arguments) throws Exception {
+        AbstractFileOrTextStep step = DescribableHelper.instantiate(stepType, arguments);
+        if (isBlank(step.getFile()) && isBlank(step.getText())) {
+            throw new IllegalArgumentException("At least one of file or text needs to be provided.");
+        }
+        return step;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/AbstractFileOrTextStepDescriptorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/AbstractFileOrTextStepDescriptorImpl.java
@@ -1,25 +1,22 @@
 package org.jenkinsci.plugins.pipeline.utility.steps;
 
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
-import org.jenkinsci.plugins.workflow.structs.DescribableHelper;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
 
 import java.util.Map;
 
 import static org.apache.commons.lang.StringUtils.isBlank;
 
 public abstract class AbstractFileOrTextStepDescriptorImpl extends AbstractStepDescriptorImpl {
-    private final Class<? extends AbstractFileOrTextStep> stepType;
-
-    public AbstractFileOrTextStepDescriptorImpl(Class<? extends AbstractFileOrTextStep> stepType, Class<? extends AbstractFileOrTextStepExecution> executionType) {
+    protected AbstractFileOrTextStepDescriptorImpl(Class<? extends StepExecution> executionType) {
         super(executionType);
-        this.stepType = stepType;
     }
 
     @Override
     public AbstractFileOrTextStep newInstance(Map<String, Object> arguments) throws Exception {
-        AbstractFileOrTextStep step = DescribableHelper.instantiate(stepType, arguments);
+        AbstractFileOrTextStep step = (AbstractFileOrTextStep) super.newInstance(arguments);
         if (isBlank(step.getFile()) && isBlank(step.getText())) {
-            throw new IllegalArgumentException("At least one of file or text needs to be provided.");
+            throw new IllegalArgumentException(Messages.AbstractFileOrTextStepDescriptorImpl_missingRequiredArgument(getFunctionName()));
         }
         return step;
     }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/AbstractFileOrTextStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/AbstractFileOrTextStepExecution.java
@@ -1,0 +1,25 @@
+package org.jenkinsci.plugins.pipeline.utility.steps;
+
+import hudson.FilePath;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.MissingContextVariableException;
+
+import javax.inject.Inject;
+
+import static org.apache.commons.lang.StringUtils.isNotBlank;
+
+public abstract class AbstractFileOrTextStepExecution<T> extends AbstractSynchronousNonBlockingStepExecution<T> {
+    @Inject
+    private transient AbstractFileOrTextStep fileOrTextStep;
+
+    protected FilePath ws;
+
+    @Override
+    protected T run() throws Exception {
+        ws = getContext().get(FilePath.class);
+        if (ws == null && isNotBlank(fileOrTextStep.getFile())) {
+            throw new MissingContextVariableException(FilePath.class);
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/AbstractFileOrTextStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/AbstractFileOrTextStepExecution.java
@@ -15,11 +15,13 @@ public abstract class AbstractFileOrTextStepExecution<T> extends AbstractSynchro
     protected FilePath ws;
 
     @Override
-    protected T run() throws Exception {
+    protected final T run() throws Exception {
         ws = getContext().get(FilePath.class);
         if (ws == null && isNotBlank(fileOrTextStep.getFile())) {
             throw new MissingContextVariableException(FilePath.class);
         }
-        return null;
+        return doRun();
     }
+
+    protected abstract T doRun() throws Exception;
 }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep.java
@@ -66,7 +66,7 @@ public class ReadPropertiesStep extends AbstractFileOrTextStep {
     @Extension
     public static class DescriptorImpl extends AbstractFileOrTextStepDescriptorImpl {
         public DescriptorImpl() {
-            super(ReadPropertiesStep.class, ReadPropertiesStepExecution.class);
+            super(ReadPropertiesStepExecution.class);
         }
 
         @Override

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep.java
@@ -25,66 +25,23 @@
 package org.jenkinsci.plugins.pipeline.utility.steps.conf;
 
 import hudson.Extension;
-import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
-import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
-import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStep;
+import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStepDescriptorImpl;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
 import java.util.Map;
-
-import static org.apache.commons.lang.StringUtils.isBlank;
 
 /**
  * Reads java properties formatted files and texts into a map.
  *
  * @author Robert Sandell &lt;rsandell@cloudbees.com&gt;.
  */
-public class ReadPropertiesStep extends AbstractStepImpl {
-    private String file;
-    private String text;
-    private Map<String, Object> defaults;
+public class ReadPropertiesStep extends AbstractFileOrTextStep {
+    private Map defaults;
 
     @DataBoundConstructor
     public ReadPropertiesStep() {
-    }
-
-    /**
-     * The path to a file in the workspace to read the properties from.
-     *
-     * @return te path
-     */
-    public String getFile() {
-        return file;
-    }
-
-    /**
-     * The path to a file in the workspace to read the properties from.
-     *
-     * @param file the path
-     */
-    @DataBoundSetter
-    public void setFile(String file) {
-        this.file = file;
-    }
-
-    /**
-     * A String containing properties formatted data.
-     *
-     * @return text to parse
-     */
-    public String getText() {
-        return text;
-    }
-
-    /**
-     * A String containing properties formatted data.
-     *
-     * @param text text to parse
-     */
-    @DataBoundSetter
-    public void setText(String text) {
-        this.text = text;
     }
 
     /**
@@ -92,7 +49,7 @@ public class ReadPropertiesStep extends AbstractStepImpl {
      *
      * @return the defaults
      */
-    public Map<String, Object> getDefaults() {
+    public Map getDefaults() {
         return defaults;
     }
 
@@ -102,15 +59,14 @@ public class ReadPropertiesStep extends AbstractStepImpl {
      * @param defaults the defaults
      */
     @DataBoundSetter
-    public void setDefaults(Map<String, Object> defaults) {
+    public void setDefaults(Map defaults) {
         this.defaults = defaults;
     }
 
     @Extension
-    public static class DescriptorImpl extends AbstractStepDescriptorImpl {
-
+    public static class DescriptorImpl extends AbstractFileOrTextStepDescriptorImpl {
         public DescriptorImpl() {
-            super(ReadPropertiesStepExecution.class);
+            super(ReadPropertiesStep.class, ReadPropertiesStepExecution.class);
         }
 
         @Override
@@ -121,33 +77,6 @@ public class ReadPropertiesStep extends AbstractStepImpl {
         @Override
         public String getDisplayName() {
             return "Read properties from files in the workspace or text.";
-        }
-
-        @Override
-        public Step newInstance(Map<String, Object> arguments) throws Exception {
-            ReadPropertiesStep step = new ReadPropertiesStep();
-            if(arguments.containsKey("file")) {
-                Object file = arguments.get("file");
-                if (file != null) {
-                    step.setFile(file.toString());
-                }
-            }
-            if (arguments.containsKey("text")) {
-                Object text = arguments.get("text");
-                if (text != null) {
-                    step.setText(text.toString());
-                }
-            }
-            if (arguments.containsKey("defaults")) {
-                Object defaults = arguments.get("defaults");
-                if (defaults != null && defaults instanceof Map) {
-                    step.setDefaults((Map)defaults);
-                }
-            }
-            if (isBlank(step.getFile()) && isBlank(step.getText())) {
-                throw new IllegalArgumentException("At least one of file or text needs to be provided to readProperties.");
-            }
-            return step;
         }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
@@ -27,7 +27,7 @@ package org.jenkinsci.plugins.pipeline.utility.steps.conf;
 import hudson.FilePath;
 import hudson.model.TaskListener;
 import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStepExecution;
 import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 
 import javax.inject.Inject;
@@ -38,28 +38,26 @@ import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import java.util.TreeMap;
 
 /**
  * Execution of {@link ReadPropertiesStep}.
  *
  * @author Robert Sandell &lt;rsandell@cloudbees.com&gt;.
  */
-public class ReadPropertiesStepExecution extends AbstractSynchronousNonBlockingStepExecution<Map<String, Object>> {
+public class ReadPropertiesStepExecution extends AbstractFileOrTextStepExecution<Map<Object, Object>> {
 
     private static final long serialVersionUID = 1L;
 
     @StepContextParameter
     private transient TaskListener listener;
 
-    @StepContextParameter
-    private transient FilePath ws;
-
     @Inject
     private transient ReadPropertiesStep step;
 
     @Override
-    protected Map<String, Object> run() throws Exception {
+    protected Map<Object, Object> run() throws Exception {
+        super.run();
+
         PrintStream logger = listener.getLogger();
         Properties properties = new Properties();
 
@@ -85,7 +83,7 @@ public class ReadPropertiesStepExecution extends AbstractSynchronousNonBlockingS
             properties.load(sr);
         }
 
-        Map<String, Object> result = new HashMap<>();
+        Map<Object, Object> result = new HashMap<>();
         if (step.getDefaults() != null) {
             result.putAll(step.getDefaults());
         }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
@@ -38,13 +38,14 @@ import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 /**
  * Execution of {@link ReadPropertiesStep}.
  *
  * @author Robert Sandell &lt;rsandell@cloudbees.com&gt;.
  */
-public class ReadPropertiesStepExecution extends AbstractFileOrTextStepExecution<Map<Object, Object>> {
+public class ReadPropertiesStepExecution extends AbstractFileOrTextStepExecution<Map<String, Object>> {
 
     private static final long serialVersionUID = 1L;
 
@@ -55,9 +56,7 @@ public class ReadPropertiesStepExecution extends AbstractFileOrTextStepExecution
     private transient ReadPropertiesStep step;
 
     @Override
-    protected Map<Object, Object> run() throws Exception {
-        super.run();
-
+    protected Map<String, Object> doRun() throws Exception {
         PrintStream logger = listener.getLogger();
         Properties properties = new Properties();
 
@@ -83,14 +82,25 @@ public class ReadPropertiesStepExecution extends AbstractFileOrTextStepExecution
             properties.load(sr);
         }
 
-        Map<Object, Object> result = new HashMap<>();
-        if (step.getDefaults() != null) {
-            result.putAll(step.getDefaults());
-        }
-        for (Map.Entry<Object, Object> entry : properties.entrySet()) {
-            result.put(entry.getKey() != null ? entry.getKey().toString(): null, entry.getValue());
+        Map<String, Object> result = new HashMap<>();
+        addAll(step.getDefaults(), result);
+        addAll(properties, result);
+        return result;
+    }
+
+    /**
+     * addAll implementation that will coerce keys into Strings.
+     *
+     * @param src
+     * @param dst
+     */
+    private void addAll(Map src, Map<String, Object> dst) {
+        if (src == null) {
+            return;
         }
 
-        return result;
+        for (Map.Entry e : (Set<Map.Entry>) src.entrySet()) {
+            dst.put(e.getKey() != null ? e.getKey().toString(): null, e.getValue());
+        }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadYamlStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadYamlStep.java
@@ -64,7 +64,7 @@ public class ReadYamlStep extends AbstractFileOrTextStep {
 	public static class DescriptorImpl extends AbstractFileOrTextStepDescriptorImpl {
 
 		public DescriptorImpl() {
-			super(ReadYamlStep.class, Execution.class);
+			super(Execution.class);
 		}
 
 		@Override
@@ -94,9 +94,7 @@ public class ReadYamlStep extends AbstractFileOrTextStep {
 		 * 	</ul>
 		 */
 		@Override
-		protected Object run() throws Exception {
-			super.run();
-
+		protected Object doRun() throws Exception {
 			String yamlText = "";
 			if (!isBlank(step.getFile())) {
 				FilePath path = ws.child(step.getFile());

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadYamlStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadYamlStep.java
@@ -32,21 +32,18 @@ import java.io.ObjectOutputStream;
 import java.io.Reader;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 import javax.inject.Inject;
 
 import org.apache.commons.io.IOUtils;
+import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStep;
+import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStepDescriptorImpl;
+import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStepExecution;
 import org.jenkinsci.plugins.pipeline.utility.steps.shaded.org.yaml.snakeyaml.Yaml;
 import org.jenkinsci.plugins.pipeline.utility.steps.shaded.org.yaml.snakeyaml.constructor.SafeConstructor;
 import org.jenkinsci.plugins.pipeline.utility.steps.shaded.org.yaml.snakeyaml.reader.UnicodeReader;
-import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
-import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
-import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
-import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
 
 import hudson.Extension;
 import hudson.FilePath;
@@ -57,60 +54,17 @@ import hudson.model.TaskListener;
  *
  * @author Philippe GRANET &lt;philippe.granet@gmail.com&gt;.
  */
-public class ReadYamlStep extends AbstractStepImpl {
-
-	private String file;
-	private String text;
+public class ReadYamlStep extends AbstractFileOrTextStep {
 
 	@DataBoundConstructor
 	public ReadYamlStep() {
 	}
 
-	/**
-	 * Name of the yaml file to read.
-	 *
-	 * @return file name
-	 */
-	public String getFile() {
-		return file;
-	}
-
-	/**
-	 * Name of the yaml file to read.
-	 *
-	 * @param file
-	 *            file name
-	 */
-	@DataBoundSetter
-	public void setFile(String file) {
-		this.file = file;
-	}
-
-	/**
-	 * A String containing properties formatted data.
-	 *
-	 * @return text to parse
-	 */
-	public String getText() {
-		return text;
-	}
-
-	/**
-	 * A String containing properties formatted data.
-	 *
-	 * @param text
-	 *            text to parse
-	 */
-	@DataBoundSetter
-	public void setText(String text) {
-		this.text = text;
-	}
-
 	@Extension
-	public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+	public static class DescriptorImpl extends AbstractFileOrTextStepDescriptorImpl {
 
 		public DescriptorImpl() {
-			super(Execution.class);
+			super(ReadYamlStep.class, Execution.class);
 		}
 
 		@Override
@@ -122,37 +76,13 @@ public class ReadYamlStep extends AbstractStepImpl {
 		public String getDisplayName() {
 			return "Read yaml from files in the workspace or text.";
 		}
-
-		@Override
-		public Step newInstance(Map<String, Object> arguments) throws Exception {
-			ReadYamlStep step = new ReadYamlStep();
-			if (arguments.containsKey("file")) {
-				Object file = arguments.get("file");
-				if (file != null) {
-					step.setFile(file.toString());
-				}
-			}
-			if (arguments.containsKey("text")) {
-				Object text = arguments.get("text");
-				if (text != null) {
-					step.setText(text.toString());
-				}
-			}
-			if (isBlank(step.getFile()) && isBlank(step.getText())) {
-				throw new IllegalArgumentException("At least one of file or text needs to be provided to readYaml.");
-			}
-			return step;
-		}
 	}
 
-	public static class Execution extends AbstractSynchronousNonBlockingStepExecution<Object> {
+	public static class Execution extends AbstractFileOrTextStepExecution<Object> {
 		private static final long serialVersionUID = 1L;
 
 		@StepContextParameter
 		private transient TaskListener listener;
-
-		@StepContextParameter
-		private transient FilePath ws;
 
 		@Inject
 		private transient ReadYamlStep step;
@@ -165,6 +95,8 @@ public class ReadYamlStep extends AbstractStepImpl {
 		 */
 		@Override
 		protected Object run() throws Exception {
+			super.run();
+
 			String yamlText = "";
 			if (!isBlank(step.getFile())) {
 				FilePath path = ws.child(step.getFile());

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/mf/ReadManifestStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/mf/ReadManifestStep.java
@@ -47,7 +47,7 @@ public class ReadManifestStep extends AbstractFileOrTextStep {
     public static class DescriptorImpl extends AbstractFileOrTextStepDescriptorImpl {
 
         public DescriptorImpl() {
-            super(ReadManifestStep.class, ReadManifestStepExecution.class);
+            super(ReadManifestStepExecution.class);
         }
 
         @Override

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/mf/ReadManifestStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/mf/ReadManifestStep.java
@@ -25,20 +25,16 @@
 package org.jenkinsci.plugins.pipeline.utility.steps.conf.mf;
 
 import hudson.Extension;
-import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
-import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStep;
+import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStepDescriptorImpl;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * Reads a Jar Manifest.
  *
  * @author Robert Sandell &lt;rsandell@cloudbees.com&gt;.
  */
-public class ReadManifestStep extends AbstractStepImpl {
-    private String file;
-    private String text;
-
+public class ReadManifestStep extends AbstractFileOrTextStep {
     /**
      * Since the user could either use {@link #setFile(String)} or {@link #setText(String)}
      * this constructor takes no parameters.
@@ -47,48 +43,11 @@ public class ReadManifestStep extends AbstractStepImpl {
     public ReadManifestStep() {
     }
 
-    /**
-     * @return path
-     * @see #setFile(String)
-     */
-    public String getFile() {
-        return file;
-    }
-
-    /**
-     * Path to a file containing a Jar manifest.
-     * Can be a plain text file, a .jar, .war or .ear
-     *
-     * @param file path to the file to read
-     */
-    @DataBoundSetter
-    public void setFile(String file) {
-        this.file = file;
-    }
-
-    /**
-     * @return manifest content
-     * @see #setText(String)
-     */
-    public String getText() {
-        return text;
-    }
-
-    /**
-     * Parse text as text read from a manifest file.
-     *
-     * @param text manifest content
-     */
-    @DataBoundSetter
-    public void setText(String text) {
-        this.text = text;
-    }
-
     @Extension
-    public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+    public static class DescriptorImpl extends AbstractFileOrTextStepDescriptorImpl {
 
         public DescriptorImpl() {
-            super(ReadManifestStepExecution.class);
+            super(ReadManifestStep.class, ReadManifestStepExecution.class);
         }
 
         @Override

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/mf/ReadManifestStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/mf/ReadManifestStepExecution.java
@@ -26,10 +26,8 @@ package org.jenkinsci.plugins.pipeline.utility.steps.conf.mf;
 
 import hudson.FilePath;
 import hudson.model.TaskListener;
-import org.apache.commons.lang.StringUtils;
-import org.apache.tools.ant.filters.StringInputStream;
+import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStepExecution;
 import org.jenkinsci.plugins.pipeline.utility.steps.zip.UnZipStepExecution;
-import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
 import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 
 import javax.inject.Inject;
@@ -48,24 +46,21 @@ import static org.apache.commons.lang.StringUtils.isBlank;
  *
  * @author Robert Sandell &lt;rsandell@cloudbees.com&gt;.
  */
-public class ReadManifestStepExecution extends AbstractSynchronousNonBlockingStepExecution<SimpleManifest> {
+public class ReadManifestStepExecution extends AbstractFileOrTextStepExecution<SimpleManifest> {
 
     private static final long serialVersionUID = 1L;
 
     @StepContextParameter
     private transient TaskListener listener;
 
-    @StepContextParameter
-    private transient FilePath ws;
-
     @Inject
     private transient ReadManifestStep step;
 
     @Override
     protected SimpleManifest run() throws Exception {
-        if (isBlank(step.getFile()) && isBlank(step.getText())) {
-            throw new IllegalArgumentException("Need to specify either file or text to readManifest.");
-        } else if (!isBlank(step.getFile()) && !isBlank(step.getText())) {
+        super.run();
+
+        if (!isBlank(step.getFile()) && !isBlank(step.getText())) {
             throw new IllegalArgumentException("Need to specify either file or text to readManifest, can't do both.");
         } else if (!isBlank(step.getFile())) {
             return parseFile(step.getFile());

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/mf/ReadManifestStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/mf/ReadManifestStepExecution.java
@@ -57,9 +57,7 @@ public class ReadManifestStepExecution extends AbstractFileOrTextStepExecution<S
     private transient ReadManifestStep step;
 
     @Override
-    protected SimpleManifest run() throws Exception {
-        super.run();
-
+    protected SimpleManifest doRun() throws Exception {
         if (!isBlank(step.getFile()) && !isBlank(step.getText())) {
             throw new IllegalArgumentException("Need to specify either file or text to readManifest, can't do both.");
         } else if (!isBlank(step.getFile())) {

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStep.java
@@ -44,7 +44,7 @@ public class ReadJSONStep extends AbstractFileOrTextStep {
     public static class DescriptorImpl extends AbstractFileOrTextStepDescriptorImpl {
 
         public DescriptorImpl() {
-            super(ReadJSONStep.class, ReadJSONStepExecution.class);
+            super(ReadJSONStepExecution.class);
         }
 
         @Override

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStep.java
@@ -23,75 +23,28 @@
  */
 package org.jenkinsci.plugins.pipeline.utility.steps.json;
 
-import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
-import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
-import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStep;
+import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStepDescriptorImpl;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
-import org.kohsuke.stapler.StaplerRequest;
 
 import hudson.Extension;
-import hudson.Util;
-import net.sf.json.JSONObject;
 
 /**
  * Reads a JSON file from the workspace.
  *
  * @author Nikolas Falco
  */
-public class ReadJSONStep extends AbstractStepImpl {
-
-    private String file;
-    private String text;
+public class ReadJSONStep extends AbstractFileOrTextStep {
 
     @DataBoundConstructor
     public ReadJSONStep() {
     }
 
-    /**
-     * The path to a file in the workspace to read JSON content from.
-     *
-     * @return the file path
-     */
-    public String getFile() {
-        return file;
-    }
-
-    /**
-     * The path to a file in the workspace to read JSON content from.
-     *
-     * @param file the path to file in the workspace
-     */
-    @DataBoundSetter
-    public void setFile(String file) {
-        this.file = Util.fixEmpty(file);
-    }
-
-    /**
-     * A String containing JSON formatted data.
-     *
-     * @return text to parse
-     */
-    public String getText() {
-        return text;
-    }
-
-    /**
-     * A String containing JSON formatted data.
-     *
-     * @param text to parse
-     */
-    @DataBoundSetter
-    public void setText(String text) {
-        this.text = Util.fixEmpty(text);
-    }
-
     @Extension
-    public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+    public static class DescriptorImpl extends AbstractFileOrTextStepDescriptorImpl {
 
         public DescriptorImpl() {
-            super(ReadJSONStepExecution.class);
+            super(ReadJSONStep.class, ReadJSONStepExecution.class);
         }
 
         @Override
@@ -102,18 +55,6 @@ public class ReadJSONStep extends AbstractStepImpl {
         @Override
         public String getDisplayName() {
             return Messages.ReadJSONStep_DescriptorImpl_displayName();
-        }
-
-        @Override
-        public Step newInstance(StaplerRequest req, JSONObject formData) throws FormException {
-            String file = formData.getString("file");
-            String text = formData.getString("text");
-            if (StringUtils.isNotBlank(file) && StringUtils.isNotBlank(text)) {
-                // seems that FormException is not handled correctly, it is not shown at all client side
-                throw new FormException(Messages.ReadJSONStepExecution_tooManyArguments(getFunctionName()), "text");
-            }
-
-            return super.newInstance(req, formData);
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStepExecution.java
@@ -24,37 +24,35 @@
 
 package org.jenkinsci.plugins.pipeline.utility.steps.json;
 
-import static org.apache.commons.lang.StringUtils.isBlank;
-import static org.apache.commons.lang.StringUtils.isNotBlank;
-import java.io.FileNotFoundException;
-import java.io.InputStream;
-import javax.inject.Inject;
-
-import org.apache.commons.io.IOUtils;
-import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
-import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
-
 import hudson.FilePath;
 import net.sf.json.JSON;
 import net.sf.json.JSONSerializer;
+import org.apache.commons.io.IOUtils;
+import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStepExecution;
+
+import javax.inject.Inject;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+
+import static org.apache.commons.lang.StringUtils.isBlank;
+import static org.apache.commons.lang.StringUtils.isNotBlank;
 
 /**
  * Execution of {@link ReadJSONStep}.
  *
  * @author Nikolas Falco
  */
-public class ReadJSONStepExecution extends AbstractSynchronousNonBlockingStepExecution<JSON> {
+public class ReadJSONStepExecution extends AbstractFileOrTextStepExecution<JSON> {
 
     private static final long serialVersionUID = 1L;
-
-    @StepContextParameter
-    private transient FilePath ws;
 
     @Inject
     private transient ReadJSONStep step;
 
     @Override
     protected JSON run() throws Exception {
+        super.run();
+
         String fName = step.getDescriptor().getFunctionName();
         if (isNotBlank(step.getFile()) && isNotBlank(step.getText())) {
             throw new IllegalArgumentException(Messages.ReadJSONStepExecution_tooManyArguments(fName));

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStepExecution.java
@@ -50,15 +50,10 @@ public class ReadJSONStepExecution extends AbstractFileOrTextStepExecution<JSON>
     private transient ReadJSONStep step;
 
     @Override
-    protected JSON run() throws Exception {
-        super.run();
-
+    protected JSON doRun() throws Exception {
         String fName = step.getDescriptor().getFunctionName();
         if (isNotBlank(step.getFile()) && isNotBlank(step.getText())) {
             throw new IllegalArgumentException(Messages.ReadJSONStepExecution_tooManyArguments(fName));
-        }
-        if (isBlank(step.getFile()) && isBlank(step.getText())) {
-            throw new IllegalArgumentException(Messages.ReadJSONStepExecution_missingRequiredArgument(fName));
         }
 
         JSON json = null;

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStepExecution.java
@@ -31,9 +31,12 @@ import javax.inject.Inject;
 
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.MissingContextVariableException;
 import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 
 import hudson.FilePath;
+
+import static org.apache.commons.lang.StringUtils.isNotBlank;
 
 /**
  * Execution of {@link WriteJSONStep}.
@@ -57,6 +60,10 @@ public class WriteJSONStepExecution extends AbstractSynchronousNonBlockingStepEx
         }
         if (StringUtils.isBlank(step.getFile())) {
             throw new IllegalArgumentException(Messages.WriteJSONStepExecution_missingFile(step.getDescriptor().getFunctionName()));
+        }
+        if (isNotBlank(step.getFile()) && ws == null) {
+            // Need a workspace if we are writing to a file.
+            throw new MissingContextVariableException(FilePath.class);
         }
 
         FilePath path = ws.child(step.getFile());

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/Messages.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright (c) 2016, CloudBees Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+AbstractFileOrTextStepDescriptorImpl.missingRequiredArgument=At least one of file or text needs to be provided to {0}.

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/json/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/json/Messages.properties
@@ -22,7 +22,6 @@
 
 ReadJSONStep.DescriptorImpl.displayName=Read JSON from files in the workspace.
 ReadJSONStepExecution.tooManyArguments=At most one of file or text must be provided to {0}.
-ReadJSONStepExecution.missingRequiredArgument="At least one of file or text needs to be provided to {0}.
 WriteJSONStep.DescriptorImpl.displayName=Write JSON to a file in the workspace.
 WriteJSONStepExecution.missingFile=You have to provided a file for {0}.
 WriteJSONStepExecution_missingJSON=You have to provided a JSON object to save for {0}.

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepTest.java
@@ -28,6 +28,8 @@ import hudson.model.Label;
 import hudson.model.Result;
 
 import static org.jenkinsci.plugins.pipeline.utility.steps.FilenameTestsUtils.separatorsToSystemEscaped;
+
+import org.jenkinsci.plugins.pipeline.utility.steps.Messages;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -144,7 +146,7 @@ public class ReadPropertiesStepTest {
                         "  def props = readProperties()\n" +
                         "}", true));
         WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
-        j.assertLogContains("At least one of file or text needs to be provided.", run);
+        j.assertLogContains(Messages.AbstractFileOrTextStepDescriptorImpl_missingRequiredArgument("readProperties"), run);
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadYamlStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadYamlStepTest.java
@@ -113,27 +113,21 @@ public class ReadYamlStepTest {
     
     @Test
     public void readText() throws Exception {
-       
-    	File file = temp.newFile();
-    	FileUtils.writeStringToFile(file, yamlText);
-
-        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                		"  String yamlText = readFile file: '" + separatorsToSystemEscaped(file.getAbsolutePath()) + "'\n" +
-                        "  def yaml = readYaml text: yamlText\n" +
-						"  assert yaml.boolean == true\n" +
-						"  assert yaml.string == 'string'\n" +
-						"  assert yaml.integer == 3\n" +
-						"  assert yaml.double == 3.14\n" +
-						"  assert yaml.null == null\n" +
-						"  assert yaml.billTo.address.postal == 48046\n" +
-						"  assert yaml.array.size() == 2\n" +
-						"  assert yaml.array[0] == 'value1'\n" +
-						"  assert yaml.array[1] == 'value2'\n" +
-				        "  assert yaml.another == null\n" + "}",
-				        true));
-        WorkflowRun run = p.scheduleBuild2(0).get();
+		WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+		p.setDefinition(new CpsFlowDefinition(
+				"def yaml = readYaml text: '''" + yamlText + "'''\n" +
+						"assert yaml.boolean == true\n" +
+						"assert yaml.string == 'string'\n" +
+						"assert yaml.integer == 3\n" +
+						"assert yaml.double == 3.14\n" +
+						"assert yaml.null == null\n" +
+						"assert yaml.billTo.address.postal == 48046\n" +
+						"assert yaml.array.size() == 2\n" +
+						"assert yaml.array[0] == 'value1'\n" +
+						"assert yaml.array[1] == 'value2'\n" +
+						"assert yaml.another == null\n",
+				true));
+		WorkflowRun run = p.scheduleBuild2(0).get();
         System.out.println(JenkinsRule.getLog(run));
         j.assertBuildStatusSuccess(run);
     }
@@ -189,12 +183,12 @@ public class ReadYamlStepTest {
             	        true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
-    
+
     @Test
     public void readNone() throws Exception {
-    	WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-    	p.setDefinition(new CpsFlowDefinition("node('slaves') {\n" + "  def props = readYaml()\n" + "}", true));
-    	WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
-    	j.assertLogContains("At least one of file or text needs to be provided to readYaml.", run);
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("node('slaves') {\n" + "  def props = readYaml()\n" + "}", true));
+        WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+        j.assertLogContains("At least one of file or text needs to be provided.", run);
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadYamlStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadYamlStepTest.java
@@ -4,6 +4,8 @@ import java.io.File;
 
 import org.apache.commons.io.FileUtils;
 import static org.jenkinsci.plugins.pipeline.utility.steps.FilenameTestsUtils.separatorsToSystemEscaped;
+
+import org.jenkinsci.plugins.pipeline.utility.steps.Messages;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -189,6 +191,6 @@ public class ReadYamlStepTest {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("node('slaves') {\n" + "  def props = readYaml()\n" + "}", true));
         WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
-        j.assertLogContains("At least one of file or text needs to be provided.", run);
+        j.assertLogContains(Messages.AbstractFileOrTextStepDescriptorImpl_missingRequiredArgument("readYaml"), run);
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/json/ReadJSONStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/json/ReadJSONStepTest.java
@@ -80,26 +80,23 @@ public class ReadJSONStepTest {
     public void readText() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                        "  def json = readJSON text: '" + getJSON() + "'\n" +
-                        "  assert json.tags[0] == 0\n" +
-                        "  assert json.tags[1] == 1\n" +
-                        "  assert json.tags[2] == 2\n" +
-                        "}", true));
+                        "def json = readJSON text: '" + getJSON() + "'\n" +
+                        "assert json.tags[0] == 0\n" +
+                        "assert json.tags[1] == 1\n" +
+                        "assert json.tags[2] == 2\n", true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
+    @Test
     public void readDirectText() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                        "  def json = readJSON text: '[ { \"key\": 0 }, { \"key\": \"value\" }, { \"key\": true } ]'\n" +
-                        "  assert json.isArray() == true\n" +
-                        "  assert json.size() == 3\n" +
-                        "  assert json[0].key == 0\n" +
-                        "  assert json[1].key == 'value'\n" +
-                        "  assert json[2].key == true\n" +
-                        "}", true));
+                        "def json = readJSON text: '[ { \"key\": 0 }, { \"key\": \"value\" }, { \"key\": true } ]'\n" +
+                        "assert json.isArray() == true\n" +
+                        "assert json.size() == 3\n" +
+                        "assert json[0].key == 0\n" +
+                        "assert json[1].key == 'value'\n" +
+                        "assert json[2].key == true\n", true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
@@ -111,7 +108,7 @@ public class ReadJSONStepTest {
                         "  def json = readJSON()\n" +
                         "}", true));
         WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
-        j.assertLogContains(Messages.ReadJSONStepExecution_missingRequiredArgument("readJSON"), run);
+        j.assertLogContains("At least one of file or text needs to be provided.", run);
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/json/ReadJSONStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/json/ReadJSONStepTest.java
@@ -47,6 +47,8 @@ import hudson.model.Result;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
+import static org.jenkinsci.plugins.pipeline.utility.steps.Messages.AbstractFileOrTextStepDescriptorImpl_missingRequiredArgument;
+
 /**
  * Tests for {@link ReadJSONStep}.
  *
@@ -108,7 +110,7 @@ public class ReadJSONStepTest {
                         "  def json = readJSON()\n" +
                         "}", true));
         WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
-        j.assertLogContains("At least one of file or text needs to be provided.", run);
+        j.assertLogContains(AbstractFileOrTextStepDescriptorImpl_missingRequiredArgument("readJSON"), run);
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/mf/ReadManifestStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/mf/ReadManifestStepTest.java
@@ -40,6 +40,7 @@ import java.io.File;
 import java.net.URL;
 
 import static org.jenkinsci.plugins.pipeline.utility.steps.FilenameTestsUtils.separatorsToSystemEscaped;
+import static org.jenkinsci.plugins.pipeline.utility.steps.Messages.AbstractFileOrTextStepDescriptorImpl_missingRequiredArgument;
 
 /**
  * Tests for {@link ReadManifestStep}.
@@ -149,7 +150,7 @@ public class ReadManifestStepTest {
                         "}\n"
                 , true));
         WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
-        j.assertLogContains("At least one of file or text needs to be provided.", run);
+        j.assertLogContains(AbstractFileOrTextStepDescriptorImpl_missingRequiredArgument("readManifest"), run);
     }
 
     @Test


### PR DESCRIPTION
* Created abstract base classes for read steps to remove duplication.
* Updated tests to not allocate node while reading text.