### PR TITLE
Add support for sha1 step to hash files

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha1Step.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha1Step.java
@@ -107,14 +107,13 @@ public class FileSha1Step extends AbstractStepImpl {
         private class ComputeSha1 extends MasterToSlaveFileCallable<String> {
             @Override
             public String invoke(File file, VirtualChannel virtualChannel) throws IOException, InterruptedException {
-                try {
-                    if (file.exists() && file.isFile()) {
+                if (file.exists() && file.isFile()) {
+                    try {
                         return sha1(file);
-                    } else {
-                        return null;
+                    } catch (NoSuchAlgorithmException e) {
+                        throw new IOException(e.getMessage());
                     }
-                } catch (NoSuchAlgorithmException e) {
-                    e.printStackTrace();
+                } else {
                     return null;
                 }
             }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha1Step.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha1Step.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 CloudBees Inc.
+ * Copyright (c) 2017 Emanuele Zattin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,24 +24,22 @@
 
 package org.jenkinsci.plugins.pipeline.utility.steps.fs;
 
-import com.google.common.hash.HashCode;
-import com.google.common.hash.HashFunction;
-import com.google.common.hash.Hashing;
-import com.google.common.io.Files;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.Descriptor;
 import hudson.remoting.VirtualChannel;
 import hudson.util.FormValidation;
+import jenkins.MasterToSlaveFileCallable;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.*;
-import org.jenkinsci.remoting.RoleChecker;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
 import javax.inject.Inject;
-import java.io.File;
-import java.io.IOException;
+import java.io.*;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Formatter;
 
 
 /**
@@ -106,16 +104,38 @@ public class FileSha1Step extends AbstractStepImpl {
             return filePath.act(new ComputeSha1());
         }
 
-        private class ComputeSha1 implements FilePath.FileCallable<String> {
+        private class ComputeSha1 extends MasterToSlaveFileCallable<String> {
             @Override
             public String invoke(File file, VirtualChannel virtualChannel) throws IOException, InterruptedException {
-                HashFunction hf = Hashing.sha1();
-                HashCode hc = hf.newHasher().putBytes(Files.toByteArray(file)).hash();
-                return hc.toString();
+                try {
+                    if (file.exists() && file.isFile()) {
+                        return sha1(file);
+                    } else {
+                        return null;
+                    }
+                } catch (NoSuchAlgorithmException e) {
+                    e.printStackTrace();
+                    return null;
+                }
             }
 
-            @Override
-            public void checkRoles(RoleChecker roleChecker) throws SecurityException {
+            public String sha1(final File file) throws NoSuchAlgorithmException, IOException {
+                final MessageDigest messageDigest = MessageDigest.getInstance("SHA1");
+
+                try (InputStream is = new BufferedInputStream(new FileInputStream(file))) {
+                    final byte[] buffer = new byte[1024];
+                    for (int read = 0; (read = is.read(buffer)) != -1;) {
+                        messageDigest.update(buffer, 0, read);
+                    }
+                }
+
+                // Convert the byte to hex format
+                try (Formatter formatter = new Formatter()) {
+                    for (final byte b : messageDigest.digest()) {
+                        formatter.format("%02x", b);
+                    }
+                    return formatter.toString();
+                }
             }
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha1Step.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha1Step.java
@@ -1,0 +1,123 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 CloudBees Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.utility.steps.fs;
+
+import com.google.common.hash.HashCode;
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
+import com.google.common.io.Files;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.Descriptor;
+import hudson.remoting.VirtualChannel;
+import hudson.util.FormValidation;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.workflow.steps.*;
+import org.jenkinsci.remoting.RoleChecker;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+
+
+/**
+ * Compute the SHA1 of a file.
+ *
+ * @author Emanuele Zattin &lt;emanuelez@gmail.com&gt;.
+ */
+public class FileSha1Step extends AbstractStepImpl {
+    private final String file;
+
+    @DataBoundConstructor
+    public FileSha1Step(String file) throws Descriptor.FormException {
+        if (StringUtils.isBlank(file)) {
+            throw new Descriptor.FormException("can't be blank", "file");
+        }
+        this.file = file;
+    }
+
+    public String getFile() {
+        return file;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+
+        public DescriptorImpl() {
+            super(ExecutionImpl.class);
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "sha1";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Compute the SHA1 of a given file";
+        }
+
+        @SuppressWarnings("unused")
+        public FormValidation doCheckFile(@QueryParameter String value) {
+            if (StringUtils.isBlank(value)) {
+                return FormValidation.error("Needs a value");
+            } else {
+                return FormValidation.ok();
+            }
+        }
+    }
+
+    public static class ExecutionImpl extends AbstractSynchronousNonBlockingStepExecution<String> {
+        private static final long serialVersionUID = 1L;
+
+        @StepContextParameter
+        private transient FilePath ws;
+
+        @Inject
+        private transient FileSha1Step step;
+
+        @Override
+        protected String run() throws Exception {
+            FilePath filePath = ws.child(step.getFile());
+            return filePath.act(new ComputeSha1());
+        }
+
+        private class ComputeSha1 implements FilePath.FileCallable<String> {
+            @Override
+            public String invoke(File file, VirtualChannel virtualChannel) throws IOException, InterruptedException {
+                HashFunction hf = Hashing.sha1();
+                HashCode hc = hf.newHasher().putBytes(Files.toByteArray(file)).hash();
+                return hc.toString();
+            }
+
+            @Override
+            public void checkRoles(RoleChecker roleChecker) throws SecurityException {
+            }
+        }
+    }
+
+}

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha1Step/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha1Step/config.groovy
@@ -1,0 +1,33 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 CloudBees Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+package org.jenkinsci.plugins.pipeline.utility.steps.fs.FindFilesStep
+
+def f = namespace(lib.FormTagLib) as lib.FormTagLib
+
+f.entry(field: 'file', title: _('File')) {
+    f.textbox()
+}
+

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha1Step/help-file.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha1Step/help-file.html
@@ -1,7 +1,7 @@
 <!--
   ~ The MIT License (MIT)
   ~
-  ~ Copyright (c) 2017 CloudBees Inc.
+  ~ Copyright (c) 2017 Emanuele Zattin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha1Step/help-file.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha1Step/help-file.html
@@ -1,0 +1,27 @@
+<!--
+  ~ The MIT License (MIT)
+  ~
+  ~ Copyright (c) 2017 CloudBees Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in all
+  ~ copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  ~ SOFTWARE.
+  -->
+
+<p>
+    The path to the file to hash.
+</p>

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha1Step/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha1Step/help.html
@@ -1,0 +1,27 @@
+<!--
+  ~ The MIT License (MIT)
+  ~
+  ~ Copyright (c) 2017 CloudBees Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in all
+  ~ copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  ~ SOFTWARE.
+  -->
+
+<p>
+  Computes the SHA1 of a given file.
+</p>

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha1Step/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha1Step/help.html
@@ -1,7 +1,7 @@
 <!--
   ~ The MIT License (MIT)
   ~
-  ~ Copyright (c) 2017 CloudBees Inc.
+  ~ Copyright (c) 2017 Emanuele Zattin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha1StepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha1StepTest.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 CloudBees Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.utility.steps.fs;
+
+import hudson.model.Label;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * Tests {@link TouchStep}.
+ *
+ * @author Robert Sandell &lt;rsandell@cloudbees.com&gt;.
+ */
+public class FileSha1StepTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Before
+    public void setup() throws Exception {
+        j.createOnlineSlave(Label.get("slaves"));
+    }
+
+    @Test
+    public void configRoundTrip() throws Exception {
+        FileSha1Step step = new FileSha1Step("target/my.tag");
+        FileSha1Step step2 = new StepConfigTester(j).configRoundTrip(step);
+        j.assertEqualDataBoundBeans(step, step2);
+    }
+
+    @Test
+    public void testNow() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node('slaves') {\n" +
+                        "  dir('inhere') {\n" +
+                        "    touch 'emanuelewashere.tag'\n" +
+                        "    def hash = sha1 'emanuelewashere.tag'\n" +
+                        "    assert hash == 'da39a3ee5e6b4b0d3255bfef95601890afd80709'\n" + // This is the hash of an empty file
+                        "  }\n" +
+                        "}", false));
+        j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha1StepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha1StepTest.java
@@ -36,7 +36,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 /**
  * Tests {@link TouchStep}.
  *
- * @author Robert Sandell &lt;rsandell@cloudbees.com&gt;.
+ * @author Emanuele Zattin &lt;emanuelez@gmail.com&gt;.
  */
 public class FileSha1StepTest {
     @Rule


### PR DESCRIPTION
This can be useful under many circumstances, in particular when building docker images containing some kind of cache for a package manager.