### PR TITLE
Added support for interpolated variables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,16 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
+            <version>2.2</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.9.3</version>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
             <version>1.29.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -74,11 +74,6 @@
             <version>2.2</version>
         </dependency>
         <dependency>
-            <groupId>commons-beanutils</groupId>
-            <artifactId>commons-beanutils</artifactId>
-            <version>1.9.3</version>
-        </dependency>
-        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
             <version>1.29.1</version>

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep.java
@@ -39,6 +39,7 @@ import java.util.Map;
  */
 public class ReadPropertiesStep extends AbstractFileOrTextStep {
     private Map defaults;
+    private Boolean interpolate = Boolean.FALSE;
 
     @DataBoundConstructor
     public ReadPropertiesStep() {
@@ -61,6 +62,27 @@ public class ReadPropertiesStep extends AbstractFileOrTextStep {
     @DataBoundSetter
     public void setDefaults(Map defaults) {
         this.defaults = defaults;
+    }
+
+    /**
+     * Flag to indicate if the properties should be interpolated or not.
+     * I.E. :
+     *   baseUrl = http://localhost
+     *   url = ${baseUrl}/resources
+     * The value of <i>url</i> should be evaluated to http://localhost/resources with the interpolation on.
+     * @return the value of interpolated
+     */
+    public Boolean getInterpolate() {
+        return interpolate;
+    }
+
+    /**
+     * Set the interpolated parameter.
+     * @param interpolate parameter.
+     */
+    @DataBoundSetter
+    public void setInterpolate(Boolean interpolate) {
+        this.interpolate = interpolate;
     }
 
     @Extension

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep.java
@@ -39,7 +39,7 @@ import java.util.Map;
  */
 public class ReadPropertiesStep extends AbstractFileOrTextStep {
     private Map defaults;
-    private Boolean interpolate = Boolean.FALSE;
+    private boolean interpolate;
 
     @DataBoundConstructor
     public ReadPropertiesStep() {
@@ -72,7 +72,7 @@ public class ReadPropertiesStep extends AbstractFileOrTextStep {
      * The value of <i>url</i> should be evaluated to http://localhost/resources with the interpolation on.
      * @return the value of interpolated
      */
-    public Boolean getInterpolate() {
+    public Boolean isInterpolate() {
         return interpolate;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
@@ -29,8 +29,6 @@ import hudson.model.TaskListener;
 import org.apache.commons.configuration2.AbstractConfiguration;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.ConfigurationConverter;
-import org.apache.commons.configuration2.PropertiesConfiguration;
-import org.apache.commons.configuration2.builder.fluent.Configurations;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStepExecution;
 import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
@@ -88,7 +86,7 @@ public class ReadPropertiesStepExecution extends AbstractFileOrTextStepExecution
         }
 
         // Check if we should interpolated values in the properties
-        if ( step.getInterpolate() ) {
+        if ( step.isInterpolate() ) {
             logger.println("Interpolation set to true, starting to parse the variable!");
             properties = interpolateProperties(properties);
         }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
@@ -26,6 +26,11 @@ package org.jenkinsci.plugins.pipeline.utility.steps.conf;
 
 import hudson.FilePath;
 import hudson.model.TaskListener;
+import org.apache.commons.configuration2.AbstractConfiguration;
+import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.configuration2.ConfigurationConverter;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.builder.fluent.Configurations;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStepExecution;
 import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
@@ -82,6 +87,9 @@ public class ReadPropertiesStepExecution extends AbstractFileOrTextStepExecution
             properties.load(sr);
         }
 
+        // Interpolated values in the properties
+        properties = interpolateProperties(properties);
+
         Map<String, Object> result = new HashMap<>();
         addAll(step.getDefaults(), result);
         addAll(properties, result);
@@ -102,5 +110,23 @@ public class ReadPropertiesStepExecution extends AbstractFileOrTextStepExecution
         for (Map.Entry e : (Set<Map.Entry>) src.entrySet()) {
             dst.put(e.getKey() != null ? e.getKey().toString(): null, e.getValue());
         }
+    }
+
+    /**
+     * Using commons collection to interpolated the values inside the properties
+     * @param properties the list of properties to be interpolated
+     * @return a new Properties object with the interpolated values
+     */
+    private Properties interpolateProperties(Properties properties) {
+        if ( properties == null)
+            return null;
+        // Convert the Properties to a Configuration object in order to apply the interpolation
+        Configuration conf = ConfigurationConverter.getConfiguration(properties);
+
+        // Apply interpolation
+        Configuration interpolatedProp = ((AbstractConfiguration)conf).interpolatedConfiguration();
+
+        // Convert back to properties
+        return ConfigurationConverter.getProperties(interpolatedProp);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
@@ -87,8 +87,11 @@ public class ReadPropertiesStepExecution extends AbstractFileOrTextStepExecution
             properties.load(sr);
         }
 
-        // Interpolated values in the properties
-        properties = interpolateProperties(properties);
+        // Check if we should interpolated values in the properties
+        if ( step.getInterpolate() ) {
+            logger.println("Interpolation set to true, starting to parse the variable!");
+            properties = interpolateProperties(properties);
+        }
 
         Map<String, Object> result = new HashMap<>();
         addAll(step.getDefaults(), result);

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
@@ -30,14 +30,10 @@ import org.apache.commons.configuration2.AbstractConfiguration;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.ConfigurationConverter;
 import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStep;
 import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStepExecution;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
-import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 
 import javax.annotation.Nonnull;
-import javax.inject.Inject;
-
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.io.StringReader;
@@ -62,9 +58,7 @@ public class ReadPropertiesStepExecution extends AbstractFileOrTextStepExecution
 
     @Override
     protected Map<String, Object> doRun() throws Exception {
-        TaskListener listener = getContext().get(TaskListener.class);
-        assert listener != null;
-        PrintStream logger = listener.getLogger();
+        PrintStream logger = getLogger();
         Properties properties = new Properties();
 
 
@@ -123,11 +117,11 @@ public class ReadPropertiesStepExecution extends AbstractFileOrTextStepExecution
      * @param properties the list of properties to be interpolated
      * @return a new Properties object with the interpolated values
      */
-    private Properties interpolateProperties(Properties properties) {
+    private Properties interpolateProperties(Properties properties) throws Exception {
         if ( properties == null)
             return null;
         Configuration interpolatedProp;
-        PrintStream logger = listener.getLogger();
+        PrintStream logger = getLogger();
         try {
             // Convert the Properties to a Configuration object in order to apply the interpolation
             Configuration conf = ConfigurationConverter.getConfiguration(properties);
@@ -142,5 +136,16 @@ public class ReadPropertiesStepExecution extends AbstractFileOrTextStepExecution
 
         // Convert back to properties
         return ConfigurationConverter.getProperties(interpolatedProp);
+    }
+
+    /**
+     * Helper method to get the logger from the context.
+     * @return the logger from the context.
+     * @throws Exception
+     */
+    private PrintStream getLogger() throws Exception {
+        TaskListener listener = getContext().get(TaskListener.class);
+        assert listener != null;
+        return listener.getLogger();
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
@@ -120,11 +120,19 @@ public class ReadPropertiesStepExecution extends AbstractFileOrTextStepExecution
     private Properties interpolateProperties(Properties properties) {
         if ( properties == null)
             return null;
-        // Convert the Properties to a Configuration object in order to apply the interpolation
-        Configuration conf = ConfigurationConverter.getConfiguration(properties);
+        Configuration interpolatedProp;
+        PrintStream logger = listener.getLogger();
+        try {
+            // Convert the Properties to a Configuration object in order to apply the interpolation
+            Configuration conf = ConfigurationConverter.getConfiguration(properties);
 
-        // Apply interpolation
-        Configuration interpolatedProp = ((AbstractConfiguration)conf).interpolatedConfiguration();
+            // Apply interpolation
+            interpolatedProp = ((AbstractConfiguration)conf).interpolatedConfiguration();
+        } catch (Exception e) {
+            logger.println("Got exception while interpolating the variables: " + e.getMessage());
+            logger.println("Returning the original properties list!");
+            return properties;
+        }
 
         // Convert back to properties
         return ConfigurationConverter.getProperties(interpolatedProp);

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep/help.html
@@ -45,6 +45,11 @@
         An Optional Map containing default key/values.
         <em>These are added to the resulting map first.</em>
     </li>
+    <li>
+        <code>interpolate</code>:
+        Flag to indicate if the properties should be interpolated or not.
+        In case of error or cycling dependencies, the original properties will be returned.
+    </li>
 </ul>
 <p>
     <strong>Example:</strong><br/>

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep/help.html
@@ -63,4 +63,14 @@
         assert props.other == 'Override'
         </pre>
     </code>
+    <strong>Example with interpolation:</strong>
+    <code>
+        <pre>
+        def props = readProperties interpolate: true, file: 'test.properties'
+        assert props.url = 'http://localhost'
+        assert props.resource = 'README.txt'
+        // if fullUrl is defined to ${url}/${resource} then it should evaluate to http://localhost/README.txt
+        assert props.fullUrl = 'http://localhost/README.txt'
+        </pre>
+    </code>
 </p>

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepTest.java
@@ -181,4 +181,40 @@ public class ReadPropertiesStepTest {
                         "}", true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
+    @Test
+    public void readFileAndTextInterpolated() throws Exception {
+        Properties props = new Properties();
+        props.setProperty("test", "One");
+        props.setProperty("another", "Two");
+        File file = temp.newFile();
+        try (FileWriter f = new FileWriter(file)) {
+            props.store(f, "Pipeline test");
+        }
+
+        props = new Properties();
+        props.setProperty("url", "http://localhost");
+        props.setProperty("file", "book.txt");
+        props.setProperty("fileUrl", "${url}/${file}");
+        File textFile = temp.newFile();
+        try (FileWriter f = new FileWriter(textFile)) {
+            props.store(f, "Pipeline test");
+        }
+
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node('slaves') {\n" +
+                        "  String propsText = readFile file: '" + separatorsToSystemEscaped(textFile.getAbsolutePath()) + "'\n" +
+                        "  def props = readProperties text: propsText, file: '" + separatorsToSystemEscaped(file.getAbsolutePath()) + "'\n" +
+                        "  assert props['test'] == 'One'\n" +
+                        "  assert props.test == 'One'\n" +
+                        "  assert props['url'] == 'http://localhost'\n" +
+                        "  assert props.url == 'http://localhost'\n" +
+                        "  assert props['file'] == 'book.txt'\n" +
+                        "  assert props.file == 'book.txt'\n" +
+                        "  assert props['fileUrl'] == 'http://localhost/book.txt'\n" +
+                        "  assert props.fileUrl == 'http://localhost/book.txt'\n" +
+                        "  echo \"Fila magica ${props.fileUrl}\"\n" +
+                        "}", true));
+        j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    }
 }


### PR DESCRIPTION
It adds support for interpolated variables like 
var1 = value1
var2 = ${var1}-value2
It will also expand ${sys:...} and ${env:...} keys.

As a draw back it increase the size of the pull-in because of the extra three libraries form Apache Commons.
Reference : http://commons.apache.org/proper/commons-configuration/userguide/howto_utilities.html#Utility_classes_and_Tips_and_Tricks