### PR TITLE
Feature: Added the ability to suppress verbose logging during unzip step

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/mf/ReadManifestStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/mf/ReadManifestStepExecution.java
@@ -82,7 +82,7 @@ public class ReadManifestStepExecution extends AbstractFileOrTextStepExecution<S
         }
         String lcName = path.getName().toLowerCase();
         if(lcName.endsWith(".jar") || lcName.endsWith(".war") || lcName.endsWith(".ear")) {
-            Map<String, String> mf = path.act(new UnZipStepExecution.UnZipFileCallable(listener, ws, "META-INF/MANIFEST.MF", true, "UTF-8"));
+            Map<String, String> mf = path.act(new UnZipStepExecution.UnZipFileCallable(listener, ws, "META-INF/MANIFEST.MF", true, "UTF-8", false));
             String text = mf.get("META-INF/MANIFEST.MF");
             if (isBlank(text)) {
                 throw new FileNotFoundException(path.getRemote() + " does not seem to contain a manifest.");

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStep.java
@@ -202,7 +202,6 @@ public class UnZipStep extends AbstractStepImpl {
      */
     @DataBoundSetter
     public void setQuiet(boolean quiet) {
-        // this.quiet = (quiet != null) ? quiet : false;
         this.quiet = quiet;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStep.java
@@ -215,6 +215,7 @@ public class UnZipStep extends Step {
     @DataBoundSetter
     public void setQuiet(boolean quiet) {
         this.quiet = quiet;
+    }
       
     @Override
     public StepExecution start(StepContext context) throws Exception {

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStep.java
@@ -45,6 +45,7 @@ public class UnZipStep extends AbstractStepImpl {
     private String glob;
     private boolean test = false;
     private boolean read = false;
+    private boolean quiet = false;
 
     @DataBoundConstructor
     public UnZipStep(String zipFile) throws Descriptor.FormException {
@@ -153,10 +154,10 @@ public class UnZipStep extends AbstractStepImpl {
     public void setRead(boolean read) {
         this.read = read;
     }
-    
+
     /**
      * Get the charset to use when unzipping the zip file. <em>E.g. UTF-8</em>
-     * 
+     *
      * <code>String version = unzip zipFile: 'example.zip', glob: 'version.txt', read: true, charset: UTF-8</code>
      *
      * @return String specifying the charset, defaults to UTF-8
@@ -169,7 +170,7 @@ public class UnZipStep extends AbstractStepImpl {
 
     /**
      * Set the charset to use when unzipping the zip file.
-     * 
+     *
      * <code>String version = unzip zipFile: 'example.zip', glob: 'version.txt', read: true , charset: UTF-8</code>
      *
      * @param charset
@@ -179,6 +180,30 @@ public class UnZipStep extends AbstractStepImpl {
     public void setCharset(String charset)
     {
        this.charset = (charset.trim().isEmpty()) ? "UTF-8" : charset;
+    }
+
+    /**
+     * Suppress the verbose output that logs every single file that is dealt with.
+     * <em>E.g.</em>
+     * <code>unzip zipFile: 'example.zip', glob: 'version.txt', quiet: true</code>
+     *
+     * @return if verbose logging should be suppressed
+     */
+    public boolean isQuiet() {
+        return quiet;
+    }
+
+    /**
+     * Suppress the verbose output that logs every single file that is dealt with.
+     * <em>E.g.</em>
+     * <code>unzip zipFile: 'example.zip', glob: 'version.txt', quiet: true</code>
+     *
+     * @param quiet if verbose logging should be suppressed
+     */
+    @DataBoundSetter
+    public void setQuiet(boolean quiet) {
+        // this.quiet = (quiet != null) ? quiet : false;
+        this.quiet = quiet;
     }
 
     @Extension

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStepExecution.java
@@ -184,18 +184,14 @@ public class UnZipStepExecution extends SynchronousNonBlockingStepExecution<Obje
                     }
                 }
                 if (read) {
-                    if (quiet) {
-                        logger.print("Read: ");
-                        logger.print(fileCount);
-                        logger.println(" files");
-                    }
+                    logger.print("Read: ");
+                    logger.print(fileCount);
+                    logger.println(" files");
                     return strMap;
                 } else {
-                    if (quiet) {
-                        logger.print("Extracted: ");
-                        logger.print(fileCount);
-                        logger.println(" files");
-                    }
+                    logger.print("Extracted: ");
+                    logger.print(fileCount);
+                    logger.println(" files");
                     return null;
                 }
             } finally {

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStep/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStep/config.groovy
@@ -48,5 +48,6 @@ f.entry(field: 'test', title: _('Test the archive')) {
 f.entry(field: 'read', title: _('Read the file contents')) {
     f.checkbox()
 }
-
-
+f.entry(field: 'quiet', title: _('Suppress logging of each file')) {
+    f.checkbox()
+}

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStep/help-quiet.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStep/help-quiet.html
@@ -25,6 +25,6 @@
     Suppress the verbose output that logs every single file that is dealt with.
     <em>E.g.</em>
     <code>
-      unzip zipFile: 'example.zip', glob: '*.txt', quiet: true
+      unzip zipFile: 'example.zip', quiet: true
     </code>
 </p>

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStep/help-quiet.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStep/help-quiet.html
@@ -1,0 +1,30 @@
+<!--
+  ~ The MIT License (MIT)
+  ~
+  ~ Copyright (c) 2016 CloudBees Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in all
+  ~ copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  ~ SOFTWARE.
+  -->
+<p>
+    Suppress the verbose output that logs every single file that is dealt with.
+    <em>E.g.</em>
+    <code>
+      unzip zipFile: 'example.zip', glob: '*.txt', quiet: true
+    </code>
+</p>

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStepTest.java
@@ -246,6 +246,9 @@ public class UnZipStepTest {
                         "  }\n" +
                         "}", true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        j.assertLogNotContains("Extracting: hello.txt ->", run);
+        j.assertLogNotContains("Extracting: two/hello.txt ->", run);
+        j.assertLogNotContains("Extracting: hello.dat ->", run);
         j.assertLogContains("Extracted: 3 files", run);
         j.assertLogContains("Reading: Hello World!", run);
         j.assertLogContains("Reading: Hello World2!", run);
@@ -267,6 +270,8 @@ public class UnZipStepTest {
                         "  }\n" +
                         "}", false)); //For some reason the Sandbox forbids invoking Map.values?
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        j.assertLogNotContains("Reading: hello.txt", run);
+        j.assertLogNotContains("Reading: hello.dat", run);
         j.assertLogContains("Read: 2 files", run);
         j.assertLogContains("Text: Hello World!", run);
     }

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStepTest.java
@@ -61,6 +61,7 @@ public class UnZipStepTest {
         step.setDir("base/");
         step.setGlob("**/*.zip");
         step.setRead(true);
+        step.setQuiet(false);
         step.setCharset("");
 
         UnZipStep step2 = new StepConfigTester(j).configRoundTrip(step);
@@ -221,5 +222,52 @@ public class UnZipStepTest {
                 "      error('Should be okay!')\n" +
                 "}", true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    }
+
+    @Test
+    public void unzipQuiet() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node('slaves') {\n" +
+                        "  dir('zipIt') {\n" +
+                        "    writeFile file: 'hello.txt', text: 'Hello World!'\n" +
+                        "    writeFile file: 'hello.dat', text: 'Hello World!'\n" +
+                        "    dir('two') {\n" +
+                        "      writeFile file: 'hello.txt', text: 'Hello World2!'\n" +
+                        "    }\n" +
+                        "    zip zipFile: '../hello.zip'\n" +
+                        "  }\n" +
+                        "  dir('unzip') {\n" +
+                        "    unzip zipFile: '../hello.zip', quiet: true\n" +
+                        "    String txt = readFile 'hello.txt'\n" +
+                        "    echo \"Reading: ${txt}\"\n" +
+                        "    txt = readFile 'two/hello.txt'\n" +
+                        "    echo \"Reading: ${txt}\"\n" +
+                        "  }\n" +
+                        "}", true));
+        WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        j.assertLogContains("Extracted: 3 files", run);
+        j.assertLogContains("Reading: Hello World!", run);
+        j.assertLogContains("Reading: Hello World2!", run);
+    }
+
+    @Test
+    public void unzipQuietReading() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node('slaves') {\n" +
+                        "  dir('zipIt') {\n" +
+                        "    writeFile file: 'hello.txt', text: 'Hello World!'\n" +
+                        "    writeFile file: 'hello.dat', text: 'Hello World!'\n" +
+                        "    zip zipFile: '../hello.zip'\n" +
+                        "  }\n" +
+                        "  dir('unzip') {\n" +
+                        "    def txt = unzip zipFile: '../hello.zip', quiet: true, read: true\n" +
+                        "    echo \"Text: ${txt.values().join('\\n')}\"\n" +
+                        "  }\n" +
+                        "}", false)); //For some reason the Sandbox forbids invoking Map.values?
+        WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        j.assertLogContains("Read: 2 files", run);
+        j.assertLogContains("Text: Hello World!", run);
     }
 }


### PR DESCRIPTION
As mentioned in [JENKINS-40518](https://issues.jenkins-ci.org/browse/JENKINS-40518), using the unzip step results in every file dealt with being logged, which can make logs large and annoying to read. This PR adds a boolean option 'quiet' to the unzip step, which when true turns off said logging and instead prints a total file count when done. By default quiet is false.