### PR TITLE
[JENKINS-50237] - Apply workaround while Jenkins Core is not fixed/backported

### DIFF
--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -1,0 +1,2 @@
+# It is a workaround for JENKINS-50237, real patch is here: https://github.com/jenkinsci/jenkins/pull/3359
+org.apache.tools.ant.Location


### PR DESCRIPTION
It is just a hotfix for https://github.com/jenkinsci/jenkins/pull/3359, which prevents the bug from appearing in `findFiles()` Pipeline Step on 2.107.1 and 2.102...2.112

@reviewbybees @jglick 
