### PR TITLE
Added explicit charset encoding when reading json to match writing json

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStepExecution.java
@@ -67,7 +67,7 @@ public class ReadJSONStepExecution extends AbstractFileOrTextStepExecution<JSON>
             FilePath f = ws.child(step.getFile());
             if (f.exists() && !f.isDirectory()) {
                 try (InputStream is = f.read()) {
-                    json = JSONSerializer.toJSON(IOUtils.toString(is));
+                    json = JSONSerializer.toJSON(IOUtils.toString(is, "UTF-8"));
                 }
             } else if (f.isDirectory()) {
                 throw new IllegalArgumentException(Messages.JSONStepExecution_fileIsDirectory(f.getRemote()));


### PR DESCRIPTION
If the platform default encoding isn't utf-8, you can have issues reading/writing the same file.