### PR TITLE
[JENKINS-50633] - Update Pipeline: CPS requirement to 2.48 and run tests against core with JEP-200

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(findbugs: [run: true, archive:true, unstableTotalAll: "0"])
+buildPlugin(findbugs: [run: true, archive:true, unstableTotalAll: "0", jenkinsVersions: [null, "2.107.1"]])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(findbugs: [run: true, archive:true, unstableTotalAll: "0", jenkinsVersions: [null, "2.107.1"]])
+buildPlugin(findbugs: [run: true, archive:true, unstableTotalAll: "0", jenkinsVersions: [null, "2.107.2"]])

--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@
     </developers>
 
     <properties>
-        <jenkins.version>2.7.3</jenkins.version>
-        <java.level>7</java.level>
+        <jenkins.version>2.62</jenkins.version>
+        <java.level>8</java.level>
         <workflow-step-api.version>2.14</workflow-step-api.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.4</version>
+        <version>3.7</version>
     </parent>
     <artifactId>pipeline-utility-steps</artifactId>
     <packaging>hpi</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     </developers>
 
     <properties>
-        <jenkins.version>2.62</jenkins.version>
+        <jenkins.version>2.73.1</jenkins.version>
         <java.level>8</java.level>
         <workflow-step-api.version>2.14</workflow-step-api.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -70,12 +70,12 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.10</version>
+            <version>1.14</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.40</version>
+            <version>1.42</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -91,7 +91,7 @@
             <!-- Require upper bound dependencies error -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.20</version>
+            <version>2.25</version>
         </dependency>
         <dependency>
             <!-- Require upper bound dependencies error -->
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.41</version>
+            <version>2.48-20180409.122132-1</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -133,7 +133,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.14</version>
+            <version>2.17</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.48-20180409.122132-1</version>
+            <version>2.48-20180409.134424-2</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     </developers>
 
     <properties>
-        <jenkins.version>2.73.1</jenkins.version>
+        <jenkins.version>2.73.2</jenkins.version>
         <java.level>8</java.level>
         <workflow-step-api.version>2.14</workflow-step-api.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -91,7 +91,7 @@
             <!-- Require upper bound dependencies error -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.25</version>
+            <version>2.27</version>
         </dependency>
         <dependency>
             <!-- Require upper bound dependencies error -->
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.48-20180409.134424-2</version>
+            <version>2.48</version> <!-- JENKINS-50752 fix is required for writeMavenPom() -->
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/maven/WriteMavenPomStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/maven/WriteMavenPomStep.java
@@ -57,7 +57,6 @@ import java.util.Set;
 
 /**
  * Writes a maven pom file to the current working directory.
- * The step must be invoked within the {@link com.cloudbees.groovy.cps.NonCPS} context.
  * @author Robert Sandell &lt;rsandell@cloudbees.com&gt;.
  */
 public class WriteMavenPomStep extends Step {

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/maven/WriteMavenPomStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/maven/WriteMavenPomStep.java
@@ -32,7 +32,6 @@ import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
 import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable;
 import org.jenkinsci.plugins.workflow.actions.ArgumentsAction;
-import org.jenkinsci.plugins.workflow.cps.actions.ArgumentsActionFilteringStepDescriptor;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
@@ -106,7 +105,7 @@ public class WriteMavenPomStep extends Step {
     }
 
     @Extension
-    public static class DescriptorImpl extends StepDescriptor implements ArgumentsActionFilteringStepDescriptor {
+    public static class DescriptorImpl extends StepDescriptor {
 
         public DescriptorImpl() {
 
@@ -126,19 +125,6 @@ public class WriteMavenPomStep extends Step {
         @Nonnull
         public String getDisplayName() {
             return "Write a maven project file.";
-        }
-
-        @Nonnull
-        @Override
-        public Map<String, Object> filterForAction(@Nonnull Step step, @Nonnull Map<String, Object> map) {
-            if (step instanceof WriteMavenPomStep) {
-                Map<String, Object> args = new HashMap<>(map);
-                if (args.containsKey("model")) {
-                    args.replace("model", ArgumentsAction.NotStoredReason.MASKED_VALUE);
-                }
-                return args;
-            }
-            return map;
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/maven/WriteMavenPomStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/maven/WriteMavenPomStep.java
@@ -132,7 +132,6 @@ public class WriteMavenPomStep extends Step {
         @Override
         public Map<String, Object> filterForAction(@Nonnull Step step, @Nonnull Map<String, Object> map) {
             if (step instanceof WriteMavenPomStep) {
-                WriteMavenPomStep writePomStep = (WriteMavenPomStep) step;
                 Map<String, Object> args = new HashMap<>(map);
                 if (args.containsKey("model")) {
                     args.replace("model", ArgumentsAction.NotStoredReason.MASKED_VALUE);

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/mf/ReadManifestStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/mf/ReadManifestStepTest.java
@@ -96,8 +96,10 @@ public class ReadManifestStepTest {
                         "  assert man != null\n" +
                         "  assert man.main != null\n" +
                         "  echo man.main['Version']\n" +
+                        "  assert man.main['Version'] == '" + remotingVersion + "'\n" +
                         "  echo man.main['Application-Name']\n" +
                         "  assert man.main['Application-Name'] == 'Jenkins Remoting Agent'\n" +
+                        "  assert man.entries['org/kohsuke/args4j/spi/PatternOptionHandler.class']['SHA-256-Digest'] != null\n" +
                         "}\n"
                 , true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/mf/ReadManifestStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/mf/ReadManifestStepTest.java
@@ -87,18 +87,17 @@ public class ReadManifestStepTest {
     }
 
     @Test
-    public void testJar() throws Exception {
-        String remoting = new File(j.getWebAppRoot(), "WEB-INF/remoting.jar").getAbsolutePath().replace('\\', '/');
+    public void testRemotingJar() throws Exception {
+        String remotingVersion = hudson.remoting.Launcher.VERSION;
+        String remoting = new File(j.getWebAppRoot(), "WEB-INF/lib/remoting-" + remotingVersion + ".jar").getAbsolutePath().replace('\\', '/');
         p.setDefinition(new CpsFlowDefinition(
                 "node('slaves') {\n" +
                         "  def man = readManifest file: '" + separatorsToSystemEscaped(remoting) + "'\n" +
                         "  assert man != null\n" +
                         "  assert man.main != null\n" +
                         "  echo man.main['Version']\n" +
-                        "  assert man.main['Version'] == '2.60'\n" +
                         "  echo man.main['Application-Name']\n" +
                         "  assert man.main['Application-Name'] == 'Jenkins Remoting Agent'\n" +
-                        "  assert man.entries['org/kohsuke/args4j/spi/PatternOptionHandler.class']['SHA-256-Digest'] == 'lUmBNSHeOZjD1NkTEBZt2GtTPjXAP14L2gSuhPF6SnM='\n" +
                         "}\n"
                 , true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/maven/WriteMavenPomStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/maven/WriteMavenPomStepTest.java
@@ -64,36 +64,39 @@ public class WriteMavenPomStepTest {
     public void testWriteAndRead() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
+                "def @NonCPS doWrite() {\n" +
+                        "  Model pom = new Model()\n" + //checks the auto import
+                        "  pom.artifactId = 'my-test-project'\n" +
+                        "  pom.groupId = 'com.example.jenkins.test'\n" +
+                        "  pom.version = '1.1-SNAPSHOT'\n" +
+                        "  Dependency d = new Dependency()\n" +
+                        "  d.artifactId = 'pipeline-utility-steps'\n" +
+                        "  d.groupId = 'org.jenkins-ci.plugins'\n" +
+                        "  d.version = '1.0'\n" +
+                        "  d.classifier = 'hpi'\n" +
+                        "  pom.addDependency(d)\n" +
+                        "  writeMavenPom(pom)\n" +
+                        "}\n" +
+                        "def @NonCPS doRead() {\n" +
+                        "  Model m = readMavenPom file: 'inhere/pom.xml'\n" +
+                        "  assert m.artifactId == 'my-test-project'\n" +
+                        "  assert m.groupId == 'com.example.jenkins.test'\n" +
+                        "  assert m.version == '1.1-SNAPSHOT'\n" +
+                        "  Dependency dd = m.dependencies.get(0)\n" +
+                        "  assert dd.artifactId == 'pipeline-utility-steps'\n" +
+                        "  assert dd.groupId == 'org.jenkins-ci.plugins'\n" +
+                        "  assert dd.version == '1.0'\n" +
+                        "  assert dd.classifier == 'hpi'\n" +
+                        "  result = \"success\"\n" +
+                        "} \n" +
+                        "" +
+                        "node('slaves') {\n" +
                         "  dir('inhere') {\n" +
-                        "    nonCPS.exec() {\n" +
-                        "      Model pom = new Model()\n" + //checks the auto import
-                        "      pom.artifactId = 'my-test-project'\n" +
-                        "      pom.groupId = 'com.example.jenkins.test'\n" +
-                        "      pom.version = '1.1-SNAPSHOT'\n" +
-                        "      Dependency d = new Dependency()\n" +
-                        "      d.artifactId = 'pipeline-utility-steps'\n" +
-                        "      d.groupId = 'org.jenkins-ci.plugins'\n" +
-                        "      d.version = '1.0'\n" +
-                        "      d.classifier = 'hpi'\n" +
-                        "      pom.addDependency(d)\n" +
-                        "      writeMavenPom(pom)\n" +
-                        "    }\n" +
-                        "  }\n" +
+                        "    doWrite()\n" +
+                        "  }" +
                         "  \n" +
                         "  String result = \"failed\"\n" +
-                        "  nonCPS.exec() {\n" +
-                        "    Model m = readMavenPom file: 'inhere/pom.xml'\n" +
-                        "    assert m.artifactId == 'my-test-project'\n" +
-                        "    assert m.groupId == 'com.example.jenkins.test'\n" +
-                        "    assert m.version == '1.1-SNAPSHOT'\n" +
-                        "    Dependency dd = m.dependencies.get(0)\n" +
-                        "    assert dd.artifactId == 'pipeline-utility-steps'\n" +
-                        "    assert dd.groupId == 'org.jenkins-ci.plugins'\n" +
-                        "    assert dd.version == '1.0'\n" +
-                        "    assert dd.classifier == 'hpi'\n" +
-                        "    result = \"success\"\n" +
-                        "  } \n" +
+                        "  doRead()\n" +
                         "  archive '**/pom.xml'\n" +
                         "}", true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/maven/WriteMavenPomStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/maven/WriteMavenPomStepTest.java
@@ -64,7 +64,7 @@ public class WriteMavenPomStepTest {
     public void testWriteAndRead() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "def @NonCPS doWrite() {\n" +
+                "def doWrite() {\n" +
                         "  Model pom = new Model()\n" + //checks the auto import
                         "  pom.artifactId = 'my-test-project'\n" +
                         "  pom.groupId = 'com.example.jenkins.test'\n" +
@@ -77,7 +77,7 @@ public class WriteMavenPomStepTest {
                         "  pom.addDependency(d)\n" +
                         "  writeMavenPom(pom)\n" +
                         "}\n" +
-                        "def @NonCPS doRead() {\n" +
+                        "def doRead() {\n" +
                         "  Model m = readMavenPom file: 'inhere/pom.xml'\n" +
                         "  assert m.artifactId == 'my-test-project'\n" +
                         "  assert m.groupId == 'com.example.jenkins.test'\n" +

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/maven/WriteMavenPomStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/maven/WriteMavenPomStepTest.java
@@ -66,27 +66,34 @@ public class WriteMavenPomStepTest {
         p.setDefinition(new CpsFlowDefinition(
                 "node('slaves') {\n" +
                         "  dir('inhere') {\n" +
-                        "    Model pom = new Model()\n" + //checks the auto import
-                        "    pom.artifactId = 'my-test-project'\n" +
-                        "    pom.groupId = 'com.example.jenkins.test'\n" +
-                        "    pom.version = '1.1-SNAPSHOT'\n" +
-                        "    Dependency d = new Dependency()\n" +
-                        "    d.artifactId = 'pipeline-utility-steps'\n" +
-                        "    d.groupId = 'org.jenkins-ci.plugins'\n" +
-                        "    d.version = '1.0'\n" +
-                        "    d.classifier = 'hpi'\n" +
-                        "    pom.addDependency(d)\n" +
-                        "    writeMavenPom(pom)\n" +
+                        "    nonCPS.exec() {\n" +
+                        "      Model pom = new Model()\n" + //checks the auto import
+                        "      pom.artifactId = 'my-test-project'\n" +
+                        "      pom.groupId = 'com.example.jenkins.test'\n" +
+                        "      pom.version = '1.1-SNAPSHOT'\n" +
+                        "      Dependency d = new Dependency()\n" +
+                        "      d.artifactId = 'pipeline-utility-steps'\n" +
+                        "      d.groupId = 'org.jenkins-ci.plugins'\n" +
+                        "      d.version = '1.0'\n" +
+                        "      d.classifier = 'hpi'\n" +
+                        "      pom.addDependency(d)\n" +
+                        "      writeMavenPom(pom)\n" +
+                        "    }\n" +
                         "  }\n" +
-                        "  Model m = readMavenPom file: 'inhere/pom.xml'\n" +
-                        "  assert m.artifactId == 'my-test-project'\n" +
-                        "  assert m.groupId == 'com.example.jenkins.test'\n" +
-                        "  assert m.version == '1.1-SNAPSHOT'\n" +
-                        "  Dependency dd = m.dependencies.get(0)\n" +
-                        "  assert dd.artifactId == 'pipeline-utility-steps'\n" +
-                        "  assert dd.groupId == 'org.jenkins-ci.plugins'\n" +
-                        "  assert dd.version == '1.0'\n" +
-                        "  assert dd.classifier == 'hpi'\n" +
+                        "  \n" +
+                        "  String result = \"failed\"\n" +
+                        "  nonCPS.exec() {\n" +
+                        "    Model m = readMavenPom file: 'inhere/pom.xml'\n" +
+                        "    assert m.artifactId == 'my-test-project'\n" +
+                        "    assert m.groupId == 'com.example.jenkins.test'\n" +
+                        "    assert m.version == '1.1-SNAPSHOT'\n" +
+                        "    Dependency dd = m.dependencies.get(0)\n" +
+                        "    assert dd.artifactId == 'pipeline-utility-steps'\n" +
+                        "    assert dd.groupId == 'org.jenkins-ci.plugins'\n" +
+                        "    assert dd.version == '1.0'\n" +
+                        "    assert dd.classifier == 'hpi'\n" +
+                        "    result = \"success\"\n" +
+                        "  } \n" +
                         "  archive '**/pom.xml'\n" +
                         "}", true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));


### PR DESCRIPTION
Just enables CI for 2.107.1 in order to enable testing of potential JEP-200 regressions.
https://issues.jenkins-ci.org/browse/JENKINS-50633

Downstream of https://github.com/jenkinsci/workflow-cps-plugin/pull/218

@reviewbybees @rsandell 
