### PR TITLE
Deprecating readMavenPom and writeMavenPom steps

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/maven/ReadMavenPomStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/maven/ReadMavenPomStep.java
@@ -119,6 +119,12 @@ public class ReadMavenPomStep extends Step {
         public String getDisplayName() {
             return "Read a maven project file.";
         }
+
+        @Override
+        public boolean isAdvanced() {
+            return true;
+        }
+
     }
 
     public static class Execution extends SynchronousNonBlockingStepExecution<Model> {

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/maven/WriteMavenPomStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/maven/WriteMavenPomStep.java
@@ -125,6 +125,12 @@ public class WriteMavenPomStep extends Step {
         public String getDisplayName() {
             return "Write a maven project file.";
         }
+
+        @Override
+        public boolean isAdvanced() {
+            return true;
+        }
+
     }
 
     public static class Execution extends SynchronousNonBlockingStepExecution<Void> {

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/maven/ReadMavenPomStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/maven/ReadMavenPomStep/help.html
@@ -29,3 +29,8 @@
     The returned object is a
     <a href="http://maven.apache.org/components/ref/3.3.9/maven-model/apidocs/org/apache/maven/model/Model.html">Model</a> .
 </p>
+<p>
+    Avoid using this step and <code>writeMavenPom</code>.
+    It is better to use the <code>sh</code> step to run <code>mvn</code> goals:
+    <a href="https://maven.apache.org/plugins/maven-help-plugin/evaluate-mojo.html">help:evaluate</a>, for example.
+</p>

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/maven/WriteMavenPomStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/maven/WriteMavenPomStep/help.html
@@ -50,3 +50,8 @@
         </pre>
     </code>
 </p>
+<p>
+    Avoid using this step and <code>readMavenPom</code>.
+    It is better to use the <code>sh</code> step to run <code>mvn</code> goals:
+    <a href="https://www.mojohaus.org/versions-maven-plugin/set-property-mojo.html">versions:set-property</a>, for example.
+</p>


### PR DESCRIPTION
Guide people to not use them. There are problems like [JENKINS-40514](https://issues.jenkins-ci.org/browse/JENKINS-40514), the mess in #46, and above all the likely incompatibility with off-master execution. @svanoort @rsandell