### PR TITLE
Updated maven-model version to workaround MNG-6204

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
-            <version>3.3.9</version>
+            <version>3.5.4</version>
         </dependency>
         <dependency>
             <!-- Require upper bound dependencies error -->


### PR DESCRIPTION
This commit updates maven-model to workaround https://issues.apache.org/jira/browse/MNG-6204 .
The problem arise when using method readMavenPom() on a *large* pom containing m2e specific annotations ( <?m2e ignore?>, see http://www.eclipse.org/m2e/documentation/release-notes-17.html#new-syntax-for-specifying-lifecycle-mapping-metadata ).
Jenkins failed with no really usefull error message.