### PR TITLE
Include defaults in interpolation

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
@@ -62,6 +62,9 @@ public class ReadPropertiesStepExecution extends AbstractFileOrTextStepExecution
         PrintStream logger = getLogger();
         Properties properties = new Properties();
 
+        if (step.getDefaults() != null) {
+        	properties.putAll(step.getDefaults());
+        }
 
         if (!StringUtils.isBlank(step.getFile())) {
             FilePath f = ws.child(step.getFile());
@@ -92,7 +95,6 @@ public class ReadPropertiesStepExecution extends AbstractFileOrTextStepExecution
         }
 
         Map<String, Object> result = new HashMap<>();
-        addAll(step.getDefaults(), result);
         addAll(properties, result);
         return result;
     }


### PR DESCRIPTION
We've had some situations in which we needed to specify defaults and be included in variable interpolation. For example a default could be a parametrized path to certain resources, while the loaded properties file would simply contain the referenced variables, i.e.:

default as hashmap:
`[base_path: "/${application}/${environment}/${version}"]`

loaded properties file
```
application=My Application
environment=DEV
version=1.0.0
```

Current workaround would be to serialize this hashmap into a string and provide this to the readProperties method, but this seems the be a convoluted approach. This tweaks allows you to use the defaults parameter and have those defaults be included into the string interpolation. 