### PR TITLE
Dollar-slashy strings are not that safe

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/TeeStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/TeeStepTest.java
@@ -25,6 +25,8 @@
 package org.jenkinsci.plugins.pipeline.utility.steps.fs;
 
 import hudson.Functions;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.StringParameterDefinition;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -49,9 +51,11 @@ public class TeeStepTest {
         rr.then(r -> {
                 r.createSlave("remote", null, null);
                 WorkflowJob p = r.createProject(WorkflowJob.class, "p");
+                // Remote FS gets blown away during restart, alas; need JenkinsRule utility for stable agent workspace:
+                p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("WS", r.jenkins.getWorkspaceFor(p).getRemote())));
                 p.setDefinition(new CpsFlowDefinition(
                         "node('remote') {\n" +
-                        "  dir($/" + r.jenkins.getWorkspaceFor(p) + "/$) {\n" + // remote FS gets blown away during restart, alas; need JenkinsRule utility for stable agent workspace
+                        "  dir(params.WS) {\n" +
                         "    tee('x.log') {\n" +
                         "      echo 'first message'\n" +
                         "      semaphore 'wait'\n" +


### PR DESCRIPTION
Fixes a test which passed in #51 PR builds but fails in master due to a workspace name which happens to start with a `u`, sigh. I tried `.replace("\\u", "\\U")` and probably could have used `.replace('\\', '/')` but in the end it seemed clearer and safer to pass in the file path via other means.