### PR TITLE
[JENKIKNS-54355] Dynamically load java.sql classes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,13 @@
+def coreJdk11Version="2.161"
+
 buildPlugin(
     findbugs: [run: true, archive:true, unstableTotalAll: "0"],
     configurations: [
-        [ platform: "linux", jdk: "8", jenkins: null ],
-        [ platform: "windows", jdk: "8", jenkins: null ],
-        [ platform: "linux", jdk: "8", jenkins: "2.150.1", javaLevel: "8" ],
-        [ platform: "windows", jdk: "8", jenkins: "2.150.1", javaLevel: "8" ],
-        [ platform: "linux", jdk: "11", jenkins: "2.155", javaLevel: "8" ],
-        [ platform: "windows", jdk: "11", jenkins: "2.155", javaLevel: "8" ],
+            [ platform: "linux", jdk: "8", jenkins: null ],
+            [ platform: "windows", jdk: "8", jenkins: null ],
+            [ platform: "linux", jdk: "8", jenkins: coreJdk11Version, javaLevel: "8" ],
+            [ platform: "windows", jdk: "8", jenkins: coreJdk11Version, javaLevel: "8" ],
+            [ platform: "linux", jdk: "11", jenkins: coreJdk11Version, javaLevel: "8" ],
+            [ platform: "windows", jdk: "11", jenkins: coreJdk11Version, javaLevel: "8" ]
     ]
 )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,11 @@
-buildPlugin(findbugs: [run: true, archive:true, unstableTotalAll: "0"])
+buildPlugin(
+    findbugs: [run: true, archive:true, unstableTotalAll: "0"],
+    configurations: [
+        [ platform: "linux", jdk: "8", jenkins: null ],
+        [ platform: "windows", jdk: "8", jenkins: null ],
+        [ platform: "linux", jdk: "8", jenkins: "2.150.1", javaLevel: "8" ],
+        [ platform: "windows", jdk: "8", jenkins: "2.150.1", javaLevel: "8" ],
+        [ platform: "linux", jdk: "11", jenkins: "2.155", javaLevel: "8" ],
+        [ platform: "windows", jdk: "11", jenkins: "2.155", javaLevel: "8" ],
+    ]
+)

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.25</version>
+        <version>3.32</version>
         <relativePath />
     </parent>
     <artifactId>pipeline-utility-steps</artifactId>

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/shaded/org/yaml/snakeyaml/nodes/Tag.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/shaded/org/yaml/snakeyaml/nodes/Tag.java
@@ -18,17 +18,20 @@ package org.jenkinsci.plugins.pipeline.utility.steps.shaded.org.yaml.snakeyaml.n
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URI;
-import java.sql.Timestamp;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.jenkinsci.plugins.pipeline.utility.steps.shaded.org.yaml.snakeyaml.util.UriEncoder;
 import org.jenkinsci.plugins.pipeline.utility.steps.shaded.org.yaml.snakeyaml.error.YAMLException;
 
 public final class Tag implements Comparable<Tag> {
+    private final static Logger LOG = Logger.getLogger(Tag.class.getName());
+
     public static final String PREFIX = "tag:yaml.org,2002:";
     public static final Tag YAML = new Tag(PREFIX + "yaml");
     public static final Tag MERGE = new Tag(PREFIX + "merge");
@@ -61,8 +64,13 @@ public final class Tag implements Comparable<Tag> {
         //
         Set<Class<?>> timestampSet = new HashSet<Class<?>>();
         timestampSet.add(Date.class);
-        timestampSet.add(java.sql.Date.class);
-        timestampSet.add(Timestamp.class);
+        try {
+            timestampSet.add(ClassLoader.getSystemClassLoader().loadClass("java.sql.Date"));
+            timestampSet.add(ClassLoader.getSystemClassLoader().loadClass("java.sql.Timestamp"));
+        } catch (ClassNotFoundException e) {
+            LOG.log(Level.INFO, "java.sql.Date and / or java.sql.Timestamp are not available. " +
+                  "You are probably on Java 11, if so, it's ok.", e);
+        }
         COMPATIBILITY_MAP.put(TIMESTAMP, timestampSet);
     }
 


### PR DESCRIPTION
[JENKINS-54355](https://issues.jenkins-ci.org/browse/JENKINS-54355)

Tag.java has references to classes which are not longer available in Java 11, without a module addition. This could cause problem when running this plugin on a Jenkins with Java 11.

@jenkinsci/java11-support 