### PR TITLE
Also build the plugin with JDK11 on recent core

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,11 @@
-buildPlugin(findbugs: [run: true, archive:true, unstableTotalAll: "0"])
+coreJdk11Version="2.161"
+
+buildPlugin(
+  findbugs: [run: true, archive:true, unstableTotalAll: "0"],
+  configurations: [
+    [ platform: "linux", jdk: "8", jenkins: null ],
+    [ platform: "windows", jdk: "8", jenkins: null ],
+    [ platform: "linux", jdk: "11", jenkins: coreJdk11Version, javaLevel: "8" ],
+    [ platform: "windows", jdk: "11", jenkins: coreJdk11Version, javaLevel: "8" ]
+  ]
+)


### PR DESCRIPTION
Using the feature introduced in https://github.com/jenkins-infra/pipeline-library/pull/79

Similar to https://github.com/jenkinsci/buildtriggerbadge-plugin/pull/34 and https://github.com/jenkinsci/label-verifier-plugin/pull/4

@jenkinsci/java11-support @rsandell 