### PR TITLE
[JENKINS-55759] Reproduce PCT error when bumping workflow-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.121.2</jenkins.version>
         <java.level>8</java.level>
-        <workflow-step-api.version>2.14</workflow-step-api.version>
+        <workflow-step-api.version>2.16</workflow-step-api.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
             <!-- Require upper bound dependencies error -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.30</version>
+            <version>2.31</version>
         </dependency>
         <dependency>
             <!-- Require upper bound dependencies error -->


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-55759

I was trying to run this plugin on PCT on Java 11, but realized this would fail also on Java 8. 

This PR shows that the bump of `workflow-api-plugin` from `2.30` to `2.31` makes some test start to fail.

cc @rsandell 