### PR TITLE
[JENKINS-54346] && [JENKINS-55505] Fix stream handling in tee.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/TeeStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/TeeStep.java
@@ -110,7 +110,7 @@ public class TeeStep extends Step {
 
         private final FilePath f;
         private boolean transferredToRemote = false;
-        private transient RemoteOutputStream stream = null;
+        private transient OutputStream stream = null;
 
         TeeFilter(FilePath f) {
             this.f = f;
@@ -119,7 +119,7 @@ public class TeeStep extends Step {
         @SuppressWarnings("rawtypes")
         @Override
         public OutputStream decorateLogger(Run build, final OutputStream logger) throws IOException, InterruptedException {
-            return new TeeOutputStream(logger, append(f, stream));
+            return new TeeOutputStream(logger, stream = append(f, stream));
         }
 
         private static final long serialVersionUID = 1;
@@ -146,7 +146,7 @@ public class TeeStep extends Step {
             boolean saveStream = transferredToRemote;
             transferredToRemote = false;
             if (saveStream) {
-                oos.writeObject(append(f, stream));
+                oos.writeObject(stream = append(f, stream));
             }
         }
 
@@ -157,7 +157,7 @@ public class TeeStep extends Step {
             transferredToRemote = false;
             if (saveStream) {
                 // Transferred, so the stream got transferred as well.
-                stream = (RemoteOutputStream) ois.readObject();
+                stream = (OutputStream) ois.readObject();
             }
         }
 

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/TeeStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/TeeStep.java
@@ -31,8 +31,12 @@ import hudson.model.Run;
 import hudson.remoting.Channel;
 import hudson.remoting.RemoteOutputStream;
 import hudson.remoting.VirtualChannel;
-
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.ObjectInputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.StandardOpenOption;
@@ -63,6 +67,8 @@ public class TeeStep extends Step {
     }
 
     private static final class TeeTail extends BodyExecutionCallback.TailCall {
+
+        private static final long serialVersionUID = 1L;
 
         private final TeeFilter filter;
 
@@ -103,12 +109,20 @@ public class TeeStep extends Step {
     private static class TeeFilter extends ConsoleLogFilter implements Serializable {
 
         private final FilePath f;
-        private boolean append = false;   // By default create a new output.
+        private boolean transferredToRemote = false;
         private transient RemoteOutputStream stream = null;
 
         TeeFilter(FilePath f) {
             this.f = f;
         }
+
+        @SuppressWarnings("rawtypes")
+        @Override
+        public OutputStream decorateLogger(Run build, final OutputStream logger) throws IOException, InterruptedException {
+            return new TeeOutputStream(logger, append(f, stream));
+        }
+
+        private static final long serialVersionUID = 1;
 
         void close() throws IOException {
             if (stream != null) {
@@ -117,78 +131,62 @@ public class TeeStep extends Step {
             }
         }
 
-        private static final class TeeFile extends MasterToSlaveFileCallable<RemoteOutputStream> {
-
-            private static final long serialVersionUID = 1;
-
-            private final Boolean append;
-
-            public TeeFile(Boolean append) {
-                this.append = append;
-            }
-
-            @Override
-            public RemoteOutputStream invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
-                f = f.getAbsoluteFile();
-                if (!f.getParentFile().exists() && !f.getParentFile().mkdirs()) {
-                    throw new IOException("Failed to create directory " + f.getParentFile());
-                }
-                try {
-                    OutputStream os = Files.newOutputStream(f.toPath(),
-                            StandardOpenOption.CREATE,
-                            append ? StandardOpenOption.APPEND : StandardOpenOption.TRUNCATE_EXISTING,
-                            StandardOpenOption.WRITE);
-
-                    return new RemoteOutputStream(os);
-                } catch (InvalidPathException e) {
-                    throw new IOException(e);
-                }
-            }
-
-        }
-
-        private RemoteOutputStream getStream() throws IOException, InterruptedException {
-            if (stream == null) {
-                stream = f.act(new TeeFile(append));
-                // From now on, when resumed and the stream gets recreated append new data.
-                append = true;
-            }
-            return stream;
-        }
-
         private void writeObject(ObjectOutputStream oos) throws IOException, InterruptedException {
-            /**
-             * This gets called either to serialize to allow resume or to transfer to a node.
-             * When resuming, the stream gets recreated.
-             * When transferring the stream needs to transfer as well.
+            /*
+              This gets called either to serialize to allow resume or to transfer to a remote.
+              When resuming, the stream gets recreated as and when needed.
+              When transferring the stream needs to transfer as well.
+
+              The transferredToRemote is used to detect whether the stream got serialized as well
+              which is also guaranteeing backward compatibility when resuming after plug-in upgrade.
              */
+            transferredToRemote = Channel.current() != null;
             oos.defaultWriteObject();
-            if (Channel.current() == null) {
-                // Serialization for resume.
-                oos.writeBoolean(false);
-            } else {
-                // Serialization for transfer.
-                oos.writeBoolean(true);
-                oos.writeObject(getStream());
+            // Reset the transferredToRemote to ensure it doesn't get stored for resuming later.
+            boolean saveStream = transferredToRemote;
+            transferredToRemote = false;
+            if (saveStream) {
+                oos.writeObject(append(f, stream));
             }
         }
 
         private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
             ois.defaultReadObject();
-            if (ois.readBoolean()) {
+            // Reset the transferredToRemote to ensure it doesn't get stored for resuming later.
+            boolean saveStream = transferredToRemote;
+            transferredToRemote = false;
+            if (saveStream) {
                 // Transferred, so the stream got transferred as well.
                 stream = (RemoteOutputStream) ois.readObject();
             }
         }
 
-        @SuppressWarnings("rawtypes")
-        @Override
-        public OutputStream decorateLogger(Run build, final OutputStream logger) throws IOException, InterruptedException {
-            return new TeeOutputStream(logger, getStream());
+        private Object readResolve() {
+            return this;
         }
 
-        private static final long serialVersionUID = 1;
+    }
 
+    /** @see FilePath#write() */
+    private static OutputStream append(FilePath fp, OutputStream stream) throws IOException, InterruptedException {
+        if (stream == null) {
+            return fp.act(new MasterToSlaveFileCallable<OutputStream>() {
+                private static final long serialVersionUID = 1L;
+                @Override
+                public OutputStream invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
+                    f = f.getAbsoluteFile();
+                    if (!f.getParentFile().exists() && !f.getParentFile().mkdirs()) {
+                        throw new IOException("Failed to create directory " + f.getParentFile());
+                    }
+                    try {
+                        return new RemoteOutputStream(Files.newOutputStream(f.toPath(), StandardOpenOption.CREATE, StandardOpenOption.APPEND/*, StandardOpenOption.DSYNC*/));
+                    } catch (InvalidPathException e) {
+                        throw new IOException(e);
+                    }
+                }
+            });
+        }
+        return stream;
     }
 
     @Extension


### PR DESCRIPTION
Based on work from roel0 this change hopefully fixes the tee issue. It opens the stream only once and closes it at the end of the tee step.

The underlying file gets created and truncated. This is different from the current behavior but I think it is the right one as tee by default (re-)creates the file so it contains only the content tee'd into it.