### PR TITLE
chore: add regression note to changelog.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 * [JENKINS-54355](https://issues.jenkins-ci.org/browse/JENKINS-54355),[JENKINS-55759](https://issues.jenkins-ci.org/browse/JENKINS-55759) Prepare for Java 11 _([PR #55](https://github.com/jenkinsci/pipeline-utility-steps-plugin/pull/55), [PR #58](https://github.com/jenkinsci/pipeline-utility-steps-plugin/pull/58), [PR #59](https://github.com/jenkinsci/pipeline-utility-steps-plugin/pull/59), [PR #61](https://github.com/jenkinsci/pipeline-utility-steps-plugin/pull/61), [PR #63](https://github.com/jenkinsci/pipeline-utility-steps-plugin/pull/63))_
 * Add "excludes" option to skip over large directories _([PR #54](https://github.com/jenkinsci/pipeline-utility-steps-plugin/pull/54))_
 * [JENKINS-53053](https://issues.jenkins-ci.org/browse/JENKINS-53053) - Implement pipeline steps for read / writing CSV files _([PR #53](https://github.com/jenkinsci/pipeline-utility-steps-plugin/pull/53))_
+* Regression introduced: plugin is unable to be installed with `latest` tag. Please specify the version when using `install-plugins.sh` to manage this plugin.
 
 
 ## 2.2.0 (Nov 7, 2018)


### PR DESCRIPTION
Noticed this regression during rebuilds today using Jenkins:latest docker image. This is a proposal to notify consumers in the changelog until the regression has been addressed.