### PR TITLE
[JENKINS-53015] readJson return plain Java objects

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStep.java
@@ -23,16 +23,15 @@
  */
 package org.jenkinsci.plugins.pipeline.utility.steps.json;
 
+import hudson.Extension;
 import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStep;
 import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
-
-import hudson.Extension;
+import org.kohsuke.stapler.DataBoundSetter;
 
 import javax.annotation.Nonnull;
-import java.io.Serializable;
 
 /**
  * Reads a JSON file from the workspace.
@@ -40,6 +39,8 @@ import java.io.Serializable;
  * @author Nikolas Falco
  */
 public class ReadJSONStep extends AbstractFileOrTextStep {
+
+    protected boolean returnPojo;
 
     @DataBoundConstructor
     public ReadJSONStep() {
@@ -67,6 +68,29 @@ public class ReadJSONStep extends AbstractFileOrTextStep {
         public String getDisplayName() {
             return Messages.ReadJSONStep_DescriptorImpl_displayName();
         }
+    }
+
+    /**
+     * Whether to return a pure Java POJO made of Map and List or the deserialized JSON object (from json-lib).
+     * Default is JSON.
+     *
+     * @return whether to return a pure Java POJO made of Map and List or the deserialized JSON object (from json-lib).
+     * Default is JSON.
+     */
+    public boolean getReturnPojo() {
+        return returnPojo;
+    }
+
+    /**
+     * Whether to return a pure Java POJO made of Map and List or the deserialized JSON object (from json-lib).
+     * Default is JSON.
+     *
+     * @param returnPojo whether to return a pure Java POJO made of Map and List or the deserialized JSON object
+     *                   (from json-lib). Default is JSON.
+     */
+    @DataBoundSetter
+    public void setReturnPojo(boolean returnPojo) {
+        this.returnPojo = returnPojo;
     }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStep.java
@@ -24,22 +24,19 @@
 package org.jenkinsci.plugins.pipeline.utility.steps.json;
 
 import com.google.common.collect.ImmutableSet;
+import hudson.Extension;
 import hudson.FilePath;
+import hudson.Util;
 import hudson.model.TaskListener;
-import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
-import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import net.sf.json.JSON;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
-import hudson.Extension;
-import hudson.Util;
-import net.sf.json.JSON;
 import org.kohsuke.stapler.DataBoundSetter;
 
 import javax.annotation.Nonnull;
-import java.io.Serializable;
 import java.util.Set;
 
 /**
@@ -50,11 +47,11 @@ import java.util.Set;
 public class WriteJSONStep extends Step {
 
     private final String file;
-    private final JSON json;
+    private final Object json;
     private int pretty = 0;
 
     @DataBoundConstructor
-    public WriteJSONStep(String file, JSON json) {
+    public WriteJSONStep(String file, Object json) {
         this.file = Util.fixNull(file);
         this.json = json;
     }
@@ -71,9 +68,14 @@ public class WriteJSONStep extends Step {
     /**
      * Return the JSON object to save.
      *
-     * @return a {@link JSON} object
+     * <p>
+     * If it is not a {@link JSON} object, {@link net.sf.json.JSONObject#fromObject(Object)} will be used in a first
+     * step.
+     * </p>
+     *
+     * @return an object
      */
-    public JSON getJson() {
+    public Object getJson() {
         return json;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStepExecution.java
@@ -24,22 +24,16 @@
 
 package org.jenkinsci.plugins.pipeline.utility.steps.json;
 
-import java.io.FileNotFoundException;
-import java.io.OutputStreamWriter;
-
-import javax.annotation.Nonnull;
-import javax.inject.Inject;
-
-import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
-import org.jenkinsci.plugins.workflow.steps.MissingContextVariableException;
-import org.jenkinsci.plugins.workflow.steps.StepContext;
-import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
-
 import hudson.FilePath;
+import net.sf.json.JSON;
+import net.sf.json.JSONSerializer;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 
-import static org.apache.commons.lang.StringUtils.isNotBlank;
+import javax.annotation.Nonnull;
+import java.io.FileNotFoundException;
+import java.io.OutputStreamWriter;
 
 /**
  * Execution of {@link WriteJSONStep}.
@@ -72,11 +66,18 @@ public class WriteJSONStepExecution extends SynchronousNonBlockingStepExecution<
             throw new FileNotFoundException(Messages.JSONStepExecution_fileIsDirectory(path.getRemote()));
         }
 
+        JSON jsonObject;
+        if (step.getJson() instanceof JSON) {
+            jsonObject = (JSON) step.getJson();
+        } else {
+            jsonObject = JSONSerializer.toJSON(step.getJson());
+        }
+
         try (OutputStreamWriter writer = new OutputStreamWriter(path.write(), "UTF-8")) {
             if (step.getPretty() > 0) {
-                writer.write(step.getJson().toString(step.getPretty()));
+                writer.write(jsonObject.toString(step.getPretty()));
             } else {
-                step.getJson().write(writer);
+                jsonObject.write(writer);
             }
         }
         return null;

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStep/config.jelly
@@ -35,4 +35,6 @@
 	<f:entry title="${%text.title}" field="text" description="${%text.description}">
 		<f:textbox />
 	</f:entry>
+
+	<f:checkbox title="${%returnPojo.title}" field="returnPojo" tooltip="${%returnPojo.description}" />
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStep/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStep/config.properties
@@ -2,3 +2,5 @@ file.title=File
 file.description=File and Text are mutually exclusive
 text.title=Text
 text.description=Text and File are mutually exclusive
+returnPojo.title=ReturnPojo
+returnPojo.description=Whether to transform the JSON into Java pure POJO before returning it or not. Default false.

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStep/help-returnPojo.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStep/help-returnPojo.html
@@ -1,7 +1,7 @@
 <!--
   ~ The MIT License (MIT)
   ~
-  ~ Copyright (c) 2016 Nikolas Falco
+  ~ Copyright (c) 2019 Nikolas Falco
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal
@@ -22,29 +22,9 @@
   ~ SOFTWARE.
   -->
 <p>
-    Reads a file in the current working directory or a String as a plain text
-    <a href="http://www.json.org/json-it.html" target="_blank">JSON</a> file.
-    The returned object is a normal Map with String keys or a List of primitives or Map.
+	Transforms the output into a POJO type (<code>LinkedHashMap</code> or <code>ArrayList</code>) before returning it.
 </p>
 <p>
-    <strong>Example:</strong><br/>
-    <code><pre>
-def props = readJSON file: 'dir/input.json'
-assert props['attr1'] == 'One'
-assert props.attr1 == 'One'
-
-def props = readJSON text: '{ "key": "value" }'
-assert props['key'] == 'value'
-assert props.key == 'value'
-
-def props = readJSON text: '[ "a", "b"]'
-assert props[0] == 'a'
-assert props[1] == 'b'
-
-def props = readJSON text: '{ "key": null, "a": "b" }', returnPojo: true
-assert props['key'] == null
-props.each { key, value ->
-    echo "Walked through key $key and value $value"
-}
-	</pre></code>
+	By default deactivated (<code>false</code>), and a JSON object (<code>JSONObject</code> or <code>JSONArray</code>
+	from json-lib) is returned.
 </p>

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStep/help.html
@@ -30,8 +30,9 @@
 <ul>
     <li>
         <code>json</code>:
-        The <a href="http://json-lib.sourceforge.net/apidocs/jdk15/net/sf/json/JSON.html">JSON</a>
-        object to write.
+        The object to write. Can either be a
+	<a href="http://json-lib.sourceforge.net/apidocs/jdk15/net/sf/json/JSON.html">JSON</a>
+        instance or another Map/List implementation. Both are supported.
     </li>
     <li>
         <code>file</code>:

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStepTest.java
@@ -22,7 +22,9 @@
  * SOFTWARE.
  */
 
-package org.jenkinsci.plugins.pipeline.utility.steps.conf.json;
+package org.jenkinsci.plugins.pipeline.utility.steps.json;
+
+import static org.jenkinsci.plugins.pipeline.utility.steps.Messages.AbstractFileOrTextStepDescriptorImpl_missingRequiredArgument;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -33,8 +35,6 @@ import java.io.Writer;
 
 import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.pipeline.utility.steps.FilenameTestsUtils;
-import org.jenkinsci.plugins.pipeline.utility.steps.json.Messages;
-import org.jenkinsci.plugins.pipeline.utility.steps.json.ReadJSONStep;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -44,10 +44,9 @@ import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import hudson.model.Result;
+
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
-
-import static org.jenkinsci.plugins.pipeline.utility.steps.Messages.AbstractFileOrTextStepDescriptorImpl_missingRequiredArgument;
 
 /**
  * Tests for {@link ReadJSONStep}.
@@ -55,8 +54,11 @@ import static org.jenkinsci.plugins.pipeline.utility.steps.Messages.AbstractFile
  * @author Nikolas Falco
  */
 public class ReadJSONStepTest {
+    private static final String SOME_JSON = "{\"aNullValue\": null,\"tags\": [0, 1, 2, null]}";
+
     @Rule
     public JenkinsRule j = new JenkinsRule();
+
     @Rule
     public TemporaryFolder temp = new TemporaryFolder();
 
@@ -82,7 +84,7 @@ public class ReadJSONStepTest {
     public void readText() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                        "def json = readJSON text: '" + getJSON() + "'\n" +
+                "def json = readJSON text: '" + getJSON() + "'\n" +
                         "assert json.tags[0] == 0\n" +
                         "assert json.tags[1] == 1\n" +
                         "assert json.tags[2] == 2\n", true));
@@ -93,7 +95,7 @@ public class ReadJSONStepTest {
     public void readDirectText() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                        "def json = readJSON text: '[ { \"key\": 0 }, { \"key\": \"value\" }, { \"key\": true } ]'\n" +
+                "def json = readJSON text: '[ { \"key\": 0 }, { \"key\": \"value\" }, { \"key\": true } ]'\n" +
                         "assert json.isArray() == true\n" +
                         "assert json.size() == 3\n" +
                         "assert json[0].key == 0\n" +
@@ -142,6 +144,81 @@ public class ReadJSONStepTest {
             IOUtils.copy(r, f);
         }
         return FilenameTestsUtils.toPath(file);
+    }
+
+
+    @Test
+    public void readFileAsPojo() throws Exception {
+        String file = writeJSON(SOME_JSON);
+
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node {\n" +
+                        "  def json = readJSON file: '" + file + "', returnPojo: true\n" +
+                        "  assert json.subMap([]).isEmpty()\n" +
+                        "  assert json.aNullValue == null\n" +
+                        "  assert json.tags.size() == 4\n" +
+                        "  assert json.tags.unique().size() == 4\n" +
+                        "  assert json.tags[0] == 0\n" +
+                        "  assert json.tags[1] == 1\n" +
+                        "  assert json.tags[2] == 2\n" +
+                        "  assert json.tags[3] == null\n" +
+                        "}", true));
+        j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    }
+
+    @Test
+    public void readTextAsPojo() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "def json = readJSON text: '" + SOME_JSON + "', returnPojo: true\n" +
+                        "assert json.subMap([]).isEmpty()\n" +
+                        "assert json.aNullValue == null\n" +
+                        "assert json.tags.size() == 4\n" +
+                        "assert json.tags.unique().size() == 4\n" +
+                        "assert json.tags[0] == 0\n" +
+                        "assert json.tags[1] == 1\n" +
+                        "assert json.tags[2] == 2\n" +
+                        "assert json.tags[3] == null\n", true));
+        j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    }
+
+    @Test
+    public void readDirectTextAsPojo() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "def json = readJSON text: '[ { \"key\": 0 }, { \"key\": \"value\" }, { \"key\": true }, { \"key\": null } ]', returnPojo: true\n" +
+                        "assert json.size() == 4\n" +
+                        "assert json.unique().size() == 4\n" +
+                        "assert json[0].key == 0\n" +
+                        "assert json[1].key == 'value'\n" +
+                        "assert json[2].key == true\n" +
+                        "assert json[3].key == null\n", true));
+        j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    }
+
+    @Test
+    public void readNoneAsPojo() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node {\n" +
+                        "  def json = readJSON(returnPojo: true)\n" +
+                        "}", true));
+        WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+        j.assertLogContains(AbstractFileOrTextStepDescriptorImpl_missingRequiredArgument("readJSON"), run);
+    }
+
+    @Test
+    public void readFileAndTextAsPojo() throws Exception {
+        String file = writeJSON(SOME_JSON);
+
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node {\n" +
+                        "  def json = readJSON( text: '{ \"key\": \"value\" }', file: '" + file + "', returnPojo: true )\n" +
+                        "}", true));
+        WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+        j.assertLogContains(Messages.ReadJSONStepExecution_tooManyArguments("readJSON"), run);
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStepTest.java
@@ -22,10 +22,16 @@
  * SOFTWARE.
  */
 
-package org.jenkinsci.plugins.pipeline.utility.steps.conf.json;
+package org.jenkinsci.plugins.pipeline.utility.steps.json;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,8 +40,6 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 
 import org.jenkinsci.plugins.pipeline.utility.steps.FilenameTestsUtils;
-import org.jenkinsci.plugins.pipeline.utility.steps.json.Messages;
-import org.jenkinsci.plugins.pipeline.utility.steps.json.WriteJSONStep;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -45,6 +49,7 @@ import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import hudson.model.Result;
+
 import net.sf.json.JSON;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
@@ -105,7 +110,7 @@ public class WriteJSONStepTest {
                 "node {\n" +
                         "  def json = readJSON text: '" + input + "'\n" +
                         "  json[0] = null\n" +
-                        "  json["+ elements + "] = 45\n" +
+                        "  json[" + elements + "] = 45\n" +
                         "  writeJSON file: '" + FilenameTestsUtils.toPath(output) + "', json: json\n" +
                         "}", true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));


### PR DESCRIPTION
The documentation of readJSON suggests that readJSON returns plain Java objects (like readYaml does), but they are of type net.sf.json.JSON and some members of that are not whitelisted, so it is painful to work with... Additionally null values encountered in the JSON are deserialized by json-lib into either JSONNull instances or JSONObject instances with isNullObject() == true. Either way non null references that brings strange errors while looping through the data structure as Map and or List.

This contribution fixes this by still using json-lib to parse the JSON string, but then transforms the resulting JSONObject or JSONArray into plain Java datastructures LinkedHashMap and ArrayList (which are the Java objects Groovy uses for its Map `[:]` and List `[]`).

Consequently writeJSON had to be adapted as well. Currently writeJSON expects to be given an instance of JSONObject or JSONArray. As readJSON now returns LinkedHashMap and ArrayList, we need writeJSON to support those, but basically any kinds of POJOs or Map/List structure. To answer this need JSONSerializer.toJson method is used. # #