### PR TITLE
Remove usages of deprecated APIs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/jenkins/NodesByLabelStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/jenkins/NodesByLabelStep.java
@@ -95,7 +95,7 @@ public class NodesByLabelStep extends Step {
         @SuppressWarnings("unused") // used by stapler
         public ComboBoxModel doFillLabelItems() {
             ComboBoxModel cbm = new ComboBoxModel();
-            Set<Label> labels = Jenkins.getInstance().getLabels();
+            Set<Label> labels = Jenkins.get().getLabels();
             for (Label label : labels) {
                 cbm.add(label.getDisplayName());
             }


### PR DESCRIPTION
While perusing the source tree, I noticed a deprecated method:

- The documentation for [`Jenkins.getInstance()`](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#getInstance--) states: "This is a historical alias for [`getInstanceOrNull()`](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#getInstanceOrNull--) but with ambiguous nullability. Use [`get()`](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#get--) in typical cases."

We always call `getLabels()` on the result, so the code assumes that the result is non-null. Therefore `Jenkins.get()` is more appropriate to use here rather than `Jenkins.getInstanceOrNull()`. So I changed the code to use `Jenkins.get()`.