### PR TITLE
Consistently use sandbox for CpsFlowDefinitions

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadYamlStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadYamlStepTest.java
@@ -55,10 +55,7 @@ public class ReadYamlStepTest {
     }
 
     @Test
-    public void checksPrimitivesAndDatesWithoutSandbox() throws Exception {
-    	
-    	//We desactive Sandbox because Class.getName and Date.format are not permitted in Sandbox...
-    	
+    public void checksPrimitivesAndDates() throws Exception {
 		WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
 		p.setDefinition(new CpsFlowDefinition(
 				"node('slaves') {\n" + "  def yaml = readYaml text: '''" + yamlText + "'''\n" 
@@ -77,7 +74,7 @@ public class ReadYamlStepTest {
 				        "  assert yaml.array[0].getClass().getName() == 'java.lang.String'\n" +
 						"  assert yaml.array[1].getClass().getName() == 'java.lang.String'\n" +
 				        "}",
-				false));
+				true));
 		j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha1StepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha1StepTest.java
@@ -64,7 +64,7 @@ public class FileSha1StepTest {
                         "    def hash = sha1 'emanuelewashere.tag'\n" +
                         "    assert hash == 'da39a3ee5e6b4b0d3255bfef95601890afd80709'\n" + // This is the hash of an empty file
                         "  }\n" +
-                        "}", false));
+                        "}", true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/TouchStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/TouchStepTest.java
@@ -72,7 +72,7 @@ public class TouchStepTest {
                         "    echo \"Now: ${now} Changed: ${changed}\"\n" +
                         "    assert changed > now - 3000 && changed < now + 3000\n" + //Is a three seconds margin too tight or too loose?
                         "  }\n" +
-                        "}", false)); //For some reason the Sandbox forbids invoking currentTimeMillis?
+                        "}", true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStepTest.java
@@ -138,7 +138,7 @@ public class UnZipStepTest {
                         "    def txt = unzip zipFile: '../hello.zip', glob: '**/hello.txt', read: true\n" +
                         "    echo \"Text: ${txt.values().join('\\n')}\"\n" +
                         "  }\n" +
-                        "}", false)); //For some reason the Sandbox forbids invoking Map.values?
+                        "}", true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         j.assertLogContains("Reading: hello.txt", run);
         j.assertLogNotContains("Reading: hello.dat", run);
@@ -268,7 +268,7 @@ public class UnZipStepTest {
                         "    def txt = unzip zipFile: '../hello.zip', quiet: true, read: true\n" +
                         "    echo \"Text: ${txt.values().join('\\n')}\"\n" +
                         "  }\n" +
-                        "}", false)); //For some reason the Sandbox forbids invoking Map.values?
+                        "}", true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         j.assertLogNotContains("Reading: hello.txt", run);
         j.assertLogNotContains("Reading: hello.dat", run);

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepTest.java
@@ -96,7 +96,7 @@ public class ZipStepTest {
             "node {" +
                 "  writeFile file: 'hello.txt', text: 'Hello world'\n" +
                 "  zip zipFile: 'output.zip', dir: '', glob: '', archive: true\n" +
-                "}", false));
+                "}", true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         j.assertLogContains("Writing zip file", run);
@@ -116,7 +116,7 @@ public class ZipStepTest {
                 "    zip zipFile: 'output.zip', dir: '../src', glob: '', archive: true\n" +
                 "  }\n" +
                 "}\n",
-                false));
+                true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
 


### PR DESCRIPTION
While looking at the test suite for this plugin, I noticed the `CpsFlowDefinition`s in the tests don't consistently use the script security sandbox. Always using the script security sandbox makes the tests consistent with each other, and it's also a more realistic environment given that the script security sandbox should always be enabled in production.

In this change, I enabled the script security sandbox wherever it was previously disabled. In some cases, comments had been left stating that the script security sandbox had been disabled to work around some bugs in the Script Security plugin. These bugs seem to have now been resolved, since the tests now pass when using the sandbox.