### PR TITLE
findFiles exclusions textbox fix

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FindFilesStep/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FindFilesStep/config.groovy
@@ -29,6 +29,6 @@ f.entry(field: 'glob', title: _('Glob')) {
     f.textbox()
 }
 
-f.entry(field: 'exclusions', title: _('Exclusions')) {
+f.entry(field: 'excludes', title: _('Exclusions')) {
     f.textbox()
 }


### PR DESCRIPTION
Exclusion textbox didn't bind correctly to the property "excludes" of the findfiles class resulting in a generated script missing the exclusion entered by the user.
Fixed by modifying the underlying field name to match the field from the FindFiles class