### PR TITLE
Bump plugin parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <packaging>hpi</packaging>
     <version>${revision}${changelist}</version>
     <name>Pipeline Utility Steps</name>
-    <url>https://wiki.jenkins.io/display/JENKINS/Pipeline+Utility+Steps+Plugin</url>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.48</version>
+        <version>3.54</version>
         <relativePath />
     </parent>
     <artifactId>pipeline-utility-steps</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <packaging>hpi</packaging>
     <version>${revision}${changelist}</version>
     <name>Pipeline Utility Steps</name>
-    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <url>https://wiki.jenkins.io/display/JENKINS/Pipeline+Utility+Steps+Plugin</url>
 
     <licenses>
         <license>

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepTest.java
@@ -125,20 +125,20 @@ public class ZipStepTest {
         Run<WorkflowJob, WorkflowRun>.Artifact artifact = run.getArtifacts().get(0);
         assertEquals("output.zip", artifact.getFileName());
         VirtualFile file = run.getArtifactManager().root().child(artifact.relativePath);
-        ZipInputStream zip = new ZipInputStream(file.open());
-        ZipEntry entry = zip.getNextEntry();
-        while (entry != null && !entry.getName().equals("output.zip")) {
-            System.out.println("zip entry name is: " + entry.getName());
-            entry = zip.getNextEntry();
+        try (ZipInputStream zip = new ZipInputStream(file.open())) {
+            ZipEntry entry = zip.getNextEntry();
+            while (entry != null && !entry.getName().equals("output.zip")) {
+                System.out.println("zip entry name is: " + entry.getName());
+                entry = zip.getNextEntry();
+            }
+            assertNotNull("output.zip should be included in the zip", entry);
+            // we should have the the zip - but double check
+            assertEquals("output.zip", entry.getName());
+            Scanner scanner = new Scanner(zip);
+            assertTrue(scanner.hasNextLine());
+            // the file that was not a zip should be included.
+            assertEquals("not really a zip", scanner.nextLine());
         }
-        assertNotNull("output.zip should be included in the zip", entry);
-        // we should have the the zip - but double check
-        assertEquals("output.zip", entry.getName());
-        Scanner scanner = new Scanner(zip);
-        assertTrue(scanner.hasNextLine());
-        // the file that was not a zip should be included.
-        assertEquals("not really a zip", scanner.nextLine());
-        zip.close();
     }
 
     @Test
@@ -190,29 +190,29 @@ public class ZipStepTest {
         Run<WorkflowJob, WorkflowRun>.Artifact artifact = run.getArtifacts().get(0);
         assertEquals("hello.zip", artifact.getFileName());
         VirtualFile file = run.getArtifactManager().root().child(artifact.relativePath);
-        ZipInputStream zip = new ZipInputStream(file.open());
-        ZipEntry entry = zip.getNextEntry();
-        while (entry.isDirectory()) {
-            entry = zip.getNextEntry();
+        try (ZipInputStream zip = new ZipInputStream(file.open())) {
+            ZipEntry entry = zip.getNextEntry();
+            while (entry.isDirectory()) {
+                entry = zip.getNextEntry();
+            }
+            assertNotNull(entry);
+            assertEquals(basePath + "hello.txt", entry.getName());
+            try (Scanner scanner = new Scanner(zip)) {
+                assertTrue(scanner.hasNextLine());
+                assertEquals("Hello World!", scanner.nextLine());
+                assertNull("There should be no more entries", zip.getNextEntry());
+            }
         }
-        assertNotNull(entry);
-        assertEquals(basePath + "hello.txt", entry.getName());
-        try(Scanner scanner = new Scanner(zip)){
-	        assertTrue(scanner.hasNextLine());
-	        assertEquals("Hello World!", scanner.nextLine());
-	        assertNull("There should be no more entries", zip.getNextEntry());
-	        zip.close();
-        }
-	
     }
 
     private void verifyArchivedNotContainingItself(WorkflowRun run) throws IOException {
         assertTrue("Build should have artifacts", run.getHasArtifacts());
         Run<WorkflowJob, WorkflowRun>.Artifact artifact = run.getArtifacts().get(0);
         VirtualFile file = run.getArtifactManager().root().child(artifact.relativePath);
-        ZipInputStream zip = new ZipInputStream(file.open());
-        for(ZipEntry entry = zip.getNextEntry(); entry != null; entry = zip.getNextEntry()) {
-            assertNotEquals("The zip output file shouldn't contain itself", entry.getName(), artifact.getFileName());
+        try (ZipInputStream zip = new ZipInputStream(file.open())) {
+            for (ZipEntry entry = zip.getNextEntry(); entry != null; entry = zip.getNextEntry()) {
+                assertNotEquals("The zip output file shouldn't contain itself", entry.getName(), artifact.getFileName());
+            }
         }
     }
 }


### PR DESCRIPTION
Bumps the [plugin parent POM](https://github.com/jenkinsci/plugin-pom) from 3.48 to 3.54.

See [the changelog](https://github.com/jenkinsci/plugin-pom/releases) and the full diff in [the compare view](https://github.com/jenkinsci/plugin-pom/compare/plugin-3.48...plugin-3.54).