### PR TITLE
Remove unneeded configuration in buildPlugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,4 @@ def configurations = [
         [ platform: "windows", jdk: "11", jenkins: coreJdk11Version, javaLevel: "8" ]
 ]
 
-buildPlugin(
-    findbugs: [run: true, archive:true, unstableTotalAll: "0"],
-    configurations: configurations
-)
+buildPlugin(configurations: configurations)


### PR DESCRIPTION
Spotbugs reporting is being enabled by default in https://github.com/jenkins-infra/pipeline-library/pull/121, update to parent pom 4.x to use spotbugs instead of findbugs.