### PR TITLE
Removing IOException when using ZIP with "overwrite: true", and the ZIP doesn't currently exist

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepExecution.java
@@ -134,8 +134,9 @@ public class ZipStepExecution extends SynchronousNonBlockingStepExecution<Void> 
         public Integer invoke(File dir, VirtualChannel channel) throws IOException, InterruptedException {
             String canonicalZip = zipFile.getRemote();
 
-            if (overwrite) {
-                Files.deleteIfExists(Paths.get(canonicalZip));
+            Path p = Paths.get(canonicalZip);
+            if (overwrite && Files.exists(p)) {
+                Files.delete(p); //Will throw exception if it fails to delete it
             }
 
             Archiver archiver = ArchiverFactory.ZIP.create(zipFile.write());

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepExecution.java
@@ -37,17 +37,15 @@ import jenkins.util.BuildListenerAdapter;
 import org.apache.commons.lang.StringUtils;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.types.FileSet;
-import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
 import org.jenkinsci.plugins.workflow.steps.MissingContextVariableException;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
-import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 
 import javax.annotation.Nonnull;
-import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepExecution.java
@@ -133,8 +133,9 @@ public class ZipStepExecution extends SynchronousNonBlockingStepExecution<Void> 
         @Override
         public Integer invoke(File dir, VirtualChannel channel) throws IOException, InterruptedException {
             String canonicalZip = zipFile.getRemote();
-            if (overwrite && !Files.deleteIfExists(Paths.get(canonicalZip))) {
-                throw new IOException("Failed to delete " + canonicalZip);
+
+            if (overwrite) {
+                Files.deleteIfExists(Paths.get(canonicalZip));
             }
 
             Archiver archiver = ArchiverFactory.ZIP.create(zipFile.write());

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepTest.java
@@ -200,6 +200,21 @@ public class ZipStepTest {
         j.assertLogNotContains("hello.zip exists.", run);
     }
 
+    @Test
+    public void noExistingZipFileWithOverwrite() throws Exception {
+
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node('slaves') {\n" +
+                        "  writeFile file: 'hello.txt', text: 'Hello world'\n" +
+                        "  zip zipFile: 'hello.zip', glob: '**/*.txt', overwrite:true\n" +
+                        "}", true));
+        WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0).get());
+        j.assertLogNotContains("java.io.IOException", run);
+        j.assertLogNotContains("Failed to delete", run);
+        j.assertLogContains("Zipped 1 entries.", run);
+    }
+
     private void verifyArchivedHello(WorkflowRun run, String basePath) throws IOException {
         assertTrue("Build should have artifacts", run.getHasArtifacts());
         Run<WorkflowJob, WorkflowRun>.Artifact artifact = run.getArtifacts().get(0);


### PR DESCRIPTION
Hello,

Currently, when running a pipeline creating a ZIP and specifying "overwrite: true", if the destination file doesn't exist, it will throw an IOException. I've run into this issue often when running a pipeline for the first time, or after clearing a workspace.

The original pull request (https://github.com/jenkinsci/pipeline-utility-steps-plugin/pull/76) checked if the ZIP existed prior to attempting to delete, however this was lost after feedback encouraging converting to NIO2 file APIs, where it now throws an IOException. This pull request changes the functionality to be more like the original.

Return value of Files.deleteIfExists is ignored, as it indicates if the file existed or not, and for overwriting I don't believe we mind either way.

Thanks