### PR TITLE
zip fails when overwriting not existing files with overwrite equal true

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepExecution.java
@@ -133,8 +133,8 @@ public class ZipStepExecution extends SynchronousNonBlockingStepExecution<Void> 
         @Override
         public Integer invoke(File dir, VirtualChannel channel) throws IOException, InterruptedException {
             String canonicalZip = zipFile.getRemote();
-            if (overwrite && !Files.deleteIfExists(Paths.get(canonicalZip))) {
-                throw new IOException("Failed to delete " + canonicalZip);
+            if (overwrite) {
+                Files.deleteIfExists(Paths.get(canonicalZip));
             }
 
             Archiver archiver = ArchiverFactory.ZIP.create(zipFile.write());


### PR DESCRIPTION
When I used the zip step I did not expect zip to fail if zip did not exist and overwrite=true.

A false return value of files.deleteIfExists does not indicate an error but the file did not exist. 

Javadoc:
> Returns:     true if the file was deleted by this method; false if the file could not be deleted because it did not exist