### PR TITLE
[JENKINS-63373] writeYaml should support writing a list as multiple d…

### DIFF
--- a/docs/STEPS.md
+++ b/docs/STEPS.md
@@ -14,7 +14,7 @@
 * `readProperties` - Read [java properties](https://docs.oracle.com/javase/7/docs/api/java/util/Properties.html) from files in the workspace or text. ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep/help.html))
 * `readManifest` - Read a [Jar Manifest](https://docs.oracle.com/javase/7/docs/technotes/guides/jar/jar.html#JAR_Manifest). ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/mf/ReadManifestStep/help.html))
 * `readYaml` - Read [YAML](http://yaml.org) from files in the workspace or text. ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadYamlStep/help.html))
-* `writeYaml` - Write [YAML](http://yaml.org) to a file or String from an object. ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStep/help.html))
+* `writeYaml` - Write [YAML](http://yaml.org) to a file or String from an object or collection of objects. ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStep/help.html))
 * `readJSON` - Read [JSON](http://www.json.org/json-it.html) from files in the workspace or text. ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStep/help.html))
 * `writeJSON` - Write a [JSON](http://www.json.org/json-it.html) object to a files in the workspace. ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStep/help.html))
 * `readCSV` - Read [CSV](https://commons.apache.org/proper/commons-csv/) from files in the workspace or text. ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/csv/ReadCSVStep/help.html))

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStep/help.html
@@ -34,8 +34,14 @@
         If provided, then <code>returnText</code> must be <code>false</code> or omitted.
         It is required that either <code>file</code> is provided, or <code>returnText</code> is <code>true</code>.
     <li>
-        <code>data</code>:
-        A Mandatory Object containing the data to be serialized.
+        <code>data</code> <i>(optional)</i>:
+        An Optional Object containing the data to be serialized. You must specify <code>data</code> <strong>or</strong>
+        <code>datas</code>, but not both in the same invocation.
+    </li>
+    <li>
+        <code>datas</code> <i>(optional)</i>:
+        An Optional Collection containing the datas to be serialized as several YAML documents. You must specify
+        <code>data</code> <strong>or</strong> <code>datas</code>, but not both in the same invocation.
     </li>
     <li>
         <code>charset</code> <i>(optional)</i>:

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStepTest.java
@@ -78,6 +78,19 @@ public class WriteYamlStepTest {
     }
 
     @Test
+    public void writeListOfDocumentsAndRead() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "list");
+        p.setDefinition(new CpsFlowDefinition(
+                "node('slaves') {\n" +
+                        "  writeYaml file: 'test', datas: [['a': 1, 'b': 2], ['a': 3, 'b': 4]] \n" +
+                        "  def yml = readYaml file: 'test' \n" +
+                        "  assert yml == [['a': 1, 'b': 2], ['a': 3, 'b': 4]] \n"+
+                        "}",
+                true));
+        WorkflowRun b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    }
+
+    @Test
     public void writeExistingFile() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "list");
         p.setDefinition(new CpsFlowDefinition(
@@ -140,7 +153,19 @@ public class WriteYamlStepTest {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("node('slaves') {\n" + "  writeYaml file: 'some' \n" + "}", true));
         WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
-        j.assertLogContains("data parameter must be provided to writeYaml", run);
+        j.assertLogContains("data or datas parameter must be provided to writeYaml", run);
+    }
+
+    @Test
+     public void writeDataAndDatas() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+         p.setDefinition(new CpsFlowDefinition(
+                 "node('slaves') {\n" +
+                         "  writeYaml file: 'test', data: ['a': 1, 'b': 2], datas: [['a': 1], ['b': 2]] \n" +
+                         "}",
+                 true));
+        WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+        j.assertLogContains("only one of data or datas must be provided to writeYaml", run);
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStepUnitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStepUnitTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.jvnet.hudson.test.WithoutJenkins;
 
+import java.util.Arrays;
 import java.util.ArrayList;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -21,10 +22,25 @@ public class WriteYamlStepUnitTest {
     }
 
     @Test @WithoutJenkins
+    public void writeEmptyListOfDocuments() throws Exception {
+        WriteYamlStep writeStep = new WriteYamlStep("/dev/null");
+        writeStep.setDatas(new ArrayList<>());
+    }
+
+    @Test @WithoutJenkins
     public void writeInvalidObject() throws Exception {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage(equalTo("data parameter has invalid content (no-basic classes)"));
 
         WriteYamlStep writeStep = new WriteYamlStep("/dev/null", new Yaml());
+    }
+
+    @Test @WithoutJenkins
+    public void writeInvalidDocuments() throws Exception {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage(equalTo("datas parameter has invalid content (no-basic classes)"));
+
+        WriteYamlStep writeStep = new WriteYamlStep("/dev/null");
+        writeStep.setDatas(new ArrayList<>(Arrays.asList(new Yaml())));
     }
 }


### PR DESCRIPTION
…ocuments

Add a `datas` parameter to writeYaml as an alternate to `data`. `datas` must be a collection, and each element will be written as a YAML document in the file.