### PR TITLE
[JENKINS-63719] add returnText option to writeYaml

### DIFF
--- a/docs/STEPS.md
+++ b/docs/STEPS.md
@@ -14,7 +14,7 @@
 * `readProperties` - Read [java properties](https://docs.oracle.com/javase/7/docs/api/java/util/Properties.html) from files in the workspace or text. ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep/help.html))
 * `readManifest` - Read a [Jar Manifest](https://docs.oracle.com/javase/7/docs/technotes/guides/jar/jar.html#JAR_Manifest). ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/mf/ReadManifestStep/help.html))
 * `readYaml` - Read [YAML](http://yaml.org) from files in the workspace or text. ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadYamlStep/help.html))
-* `writeYaml` - Write a [YAML](http://yaml.org) file from an object. ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStep/help.html))
+* `writeYaml` - Write [YAML](http://yaml.org) to a file or String from an object. ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStep/help.html))
 * `readJSON` - Read [JSON](http://www.json.org/json-it.html) from files in the workspace or text. ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStep/help.html))
 * `writeJSON` - Write a [JSON](http://www.json.org/json-it.html) object to a files in the workspace. ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStep/help.html))
 * `readCSV` - Read [CSV](https://commons.apache.org/proper/commons-csv/) from files in the workspace or text. ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/csv/ReadCSVStep/help.html))

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStep.java
@@ -58,14 +58,19 @@ public class WriteYamlStep extends Step {
     private boolean returnText;
 
     @DataBoundConstructor
-    public WriteYamlStep(String file, @Nonnull Object data) {
-        this.file = file;
+    public WriteYamlStep(@Nonnull Object data) {
         if (data == null) {
             throw new IllegalArgumentException("data parameter must be provided to writeYaml");
         } else if (!isValidObjectType(data)) {
             throw new IllegalArgumentException("data parameter has invalid content (no-basic classes)");
         }
         this.data = data;
+    }
+
+    @Deprecated
+    public WriteYamlStep(String file, @Nonnull Object data) {
+        this(data);
+        this.file = file;
     }
 
     /**
@@ -75,6 +80,11 @@ public class WriteYamlStep extends Step {
      */
     public String getFile() {
         return file;
+    }
+
+    @DataBoundSetter
+    public void setFile(String file) {
+        this.file = file;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStep.java
@@ -55,12 +55,10 @@ public class WriteYamlStep extends Step {
     private Object data;
     private String charset;
     private boolean overwrite;
+    private boolean returnText;
 
     @DataBoundConstructor
-    public WriteYamlStep(@Nonnull String file, @Nonnull Object data) {
-        if (isBlank(file)) {
-            throw new IllegalArgumentException("file parameter must be provided to writeYaml");
-        }
+    public WriteYamlStep(String file, @Nonnull Object data) {
         this.file = file;
         if (data == null) {
             throw new IllegalArgumentException("data parameter must be provided to writeYaml");
@@ -112,6 +110,15 @@ public class WriteYamlStep extends Step {
         this.overwrite = overwrite;
     }
 
+    public boolean isReturnText() {
+        return returnText;
+    }
+
+    @DataBoundSetter
+    public void setReturnText(boolean returnText) {
+        this.returnText = returnText;
+    }
+
     private boolean isValidObjectType(Object obj) {
         if ((obj instanceof Boolean) || (obj instanceof Character) ||
             (obj instanceof Number) || (obj instanceof String) ||
@@ -139,6 +146,24 @@ public class WriteYamlStep extends Step {
 
     @Override
     public StepExecution start(StepContext context) throws Exception {
+        if (this.returnText) {
+            if (this.file != null) {
+                throw new IllegalArgumentException("cannot provide both returnText and file to writeYaml");
+            }
+            if (this.charset != null) {
+                throw new IllegalArgumentException("cannot provide both returnText and charset to writeYaml");
+            }
+            if (this.overwrite) {
+                throw new IllegalArgumentException("cannot provide both returnText and overwrite to writeYaml");
+            }
+
+            return new ReturnTextExecution(context, this);
+        }
+
+        if (isBlank(this.file)) {
+            throw new IllegalArgumentException("either file or returnText must be provided to writeYaml");
+        }
+
         return new Execution(context, this);
     }
 
@@ -163,6 +188,25 @@ public class WriteYamlStep extends Step {
         @Nonnull
         public String getDisplayName() {
             return "Write a yaml from an object.";
+        }
+    }
+
+    private static class ReturnTextExecution extends SynchronousNonBlockingStepExecution<String> {
+        private static final long serialVersionUID = 1L;
+
+        private transient WriteYamlStep step;
+
+        protected ReturnTextExecution(@Nonnull StepContext context, WriteYamlStep step) {
+            super(context);
+            this.step = step;
+        }
+
+        @Override
+        protected String run() throws Exception {
+            DumperOptions options = new DumperOptions();
+            options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+            Yaml yaml = new Yaml(options);
+            return yaml.dump(step.getData());
         }
     }
 

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStep/config.jelly
@@ -27,11 +27,13 @@
 	<f:entry title="${%file.title}" field="file" description="${%file.description}">
 		<f:textbox />
 	</f:entry>
-
 	<f:entry title="${%text.title}" field="data" description="${%text.description}">
 		<f:textbox />
 	</f:entry>
 	<f:entry title="${%charset.title}" field="charset" description="${%charset.description}">
 		<f:textbox />
+	</f:entry>
+	<f:entry title="${%returnText.title}" field="returnText" description="${%returnText.description}">
+		<f:checkbox />
 	</f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStep/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStep/config.properties
@@ -4,3 +4,5 @@ text.title=Data
 text.description=Object to serialize to YAML. Must be Boolean, Character, Number, String, URL, Calendar, Date, UUID, null or a Collection/Map of them.
 charset.title=Charset
 charset.description=(Optional) What charset to use when writing the file. Default: UTF-8
+returnText.title=Return Text
+returnText.description=Whether to return the YAML as a string instead of writing it to a file.

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStep/help.html
@@ -22,16 +22,17 @@
   ~ SOFTWARE.
   -->
 <p>
-    Writes a yaml file in the current working directory from an Object or a String.
+    Writes yaml to a file in the current working directory or a String from an Object or a String.
     It uses <a href="https://bitbucket.org/asomov/snakeyaml" target="_blank">SnakeYAML</a> as YAML processor.
     The call will fail if the file already exists.
 </p>
 <strong>Fields:</strong>
 <ul>
     <li>
-        <code>file</code>:
-        Mandatory path to a file in the workspace to write the YAML datas to.
-    </li>
+        <code>file</code> <i>(optional)</i>:
+        Optional path to a file in the workspace to write the YAML datas to.
+        If provided, then <code>returnText</code> must be <code>false</code> or omitted.
+        It is required that either <code>file</code> is provided, or <code>returnText</code> is <code>true</code>.
     <li>
         <code>data</code>:
         A Mandatory Object containing the data to be serialized.
@@ -54,9 +55,16 @@
         <code>overwrite</code> <i>(optional)</i>:
         Allow existing files to be overwritten. Defaults to <code>false</code>.
     </li>
+    <li>
+        <code>returnText</code> <i>(optional)</i>:
+        Return the YAML as a string instead of writing it to a file. Defaults to <code>false</code>.
+        If <code>true</code>, then <code>file</code>, <code>charset</code>, and <code>overwrite</code> must not be provided.
+        It is required that either <code>file</code> is provided, or <code>returnText</code> is <code>true</code>.
+    </li>
 </ul>
 <p>
     <strong>Examples:</strong><br/>
+    Writing to a file:
     <code>
         <pre>
         def amap = ['something': 'my datas',
@@ -65,6 +73,21 @@
 
         writeYaml file: 'datas.yaml', data: amap
         def read = readYaml file: 'datas.yaml'
+
+        assert read.something == 'my datas'
+        assert read.size == 3
+        assert read.isEmpty == false
+        </pre>
+    </code>
+    Writing to a string:
+    <code>
+        <pre>
+        def amap = ['something': 'my datas',
+                    'size': 3,
+                    'isEmpty': false]
+
+        String yml = writeYaml returnText: true, data: amap
+        def read = readYaml text: yml
 
         assert read.something == 'my datas'
         assert read.size == 3

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStepTest.java
@@ -148,7 +148,7 @@ public class WriteYamlStepTest {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("node('slaves') {\n" + "  writeYaml data: 'some', file: '' \n" + "}", true));
         WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
-        j.assertLogContains("file parameter must be provided to writeYaml", run);
+        j.assertLogContains("either file or returnText must be provided to writeYaml", run);
     }
 
     @Test
@@ -192,5 +192,18 @@ public class WriteYamlStepTest {
                 true));
         WorkflowRun b = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
         j.assertLogContains("data parameter has invalid content (no-basic classes)", b);
+    }
+
+    @Test
+    public void returnText() throws Exception {
+		WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "map");
+		p.setDefinition(new CpsFlowDefinition(
+				  "node('slaves') {\n" +
+						 "  String written = writeYaml returnText: true, data: ['a': 1, 'b': 2] \n" +
+                         "  def yml = readYaml text: written \n" +
+                         "  assert yml == ['a' : 1, 'b': 2] \n" +
+						 "}",
+				true));
+		WorkflowRun b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 }


### PR DESCRIPTION
Adds a `returnText` boolean parameter to `writeYaml` so it returns the yaml as a string rather than writing it to a file.