### PR TITLE
[JENKINS-63720] add returnText option to writeJSON

### DIFF
--- a/docs/STEPS.md
+++ b/docs/STEPS.md
@@ -16,7 +16,7 @@
 * `readYaml` - Read [YAML](http://yaml.org) from files in the workspace or text. ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadYamlStep/help.html))
 * `writeYaml` - Write [YAML](http://yaml.org) to a file or String from an object. ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStep/help.html))
 * `readJSON` - Read [JSON](http://www.json.org/json-it.html) from files in the workspace or text. ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStep/help.html))
-* `writeJSON` - Write a [JSON](http://www.json.org/json-it.html) object to a files in the workspace. ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStep/help.html))
+* `writeJSON` - Write a [JSON](http://www.json.org/json-it.html) object to a file in the workspace, or to a String. ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStep/help.html))
 * `readCSV` - Read [CSV](https://commons.apache.org/proper/commons-csv/) from files in the workspace or text. ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/csv/ReadCSVStep/help.html))
 * `writeCSV` - Write a [CSV](https://commons.apache.org/proper/commons-csv/) file from an object. ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/csv/WriteCSVStep/help.html))
 

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStepExecution.java
@@ -25,9 +25,6 @@
 package org.jenkinsci.plugins.pipeline.utility.steps.json;
 
 import hudson.FilePath;
-import net.sf.json.JSON;
-import net.sf.json.JSONSerializer;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 
@@ -54,31 +51,14 @@ public class WriteJSONStepExecution extends SynchronousNonBlockingStepExecution<
     protected Void run() throws Exception {
         FilePath ws = getContext().get(FilePath.class);
         assert ws != null;
-        if (step.getJson() == null) {
-            throw new IllegalArgumentException(Messages.WriteJSONStepExecution_missingJSON(step.getDescriptor().getFunctionName()));
-        }
-        if (StringUtils.isBlank(step.getFile())) {
-            throw new IllegalArgumentException(Messages.WriteJSONStepExecution_missingFile(step.getDescriptor().getFunctionName()));
-        }
 
         FilePath path = ws.child(step.getFile());
         if (path.isDirectory()) {
             throw new FileNotFoundException(Messages.JSONStepExecution_fileIsDirectory(path.getRemote()));
         }
 
-        JSON jsonObject;
-        if (step.getJson() instanceof JSON) {
-            jsonObject = (JSON) step.getJson();
-        } else {
-            jsonObject = JSONSerializer.toJSON(step.getJson());
-        }
-
         try (OutputStreamWriter writer = new OutputStreamWriter(path.write(), "UTF-8")) {
-            if (step.getPretty() > 0) {
-                writer.write(jsonObject.toString(step.getPretty()));
-            } else {
-                jsonObject.write(writer);
-            }
+            step.execute(writer);
         }
         return null;
     }

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/json/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/json/Messages.properties
@@ -23,7 +23,8 @@
 ReadJSONStep.DescriptorImpl.displayName=Read JSON from files in the workspace.
 ReadJSONStepExecution.tooManyArguments=At most one of file or text must be provided to {0}.
 WriteJSONStep.DescriptorImpl.displayName=Write JSON to a file in the workspace.
-WriteJSONStepExecution.missingFile=You have to provided a file for {0}.
 WriteJSONStepExecution_missingJSON=You have to provided a JSON object to save for {0}.
+WriteJSONStepExecution_missingReturnTextAndFile=You have to provide either file or returnText to {0}.
+WriteJSONStepExecution_bothReturnTextAndFile=You cannot provide both returnText and file to {0}.
 JSONStepExecution.fileIsDirectory={0} is a directory.
 JSONStepExecution.fileNotFound={0} does not exist.

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStep/help.html
@@ -23,8 +23,8 @@
   -->
 
 <p>
-    Write a <a href="http://www.json.org/json-it.html" target="_blank">JSON</a> file in the
-    current working directory. That for example was previously read by <code>readJSON</code>.
+    Write <a href="http://www.json.org/json-it.html" target="_blank">JSON</a> to a file in the
+    current working directory, or to a String.
 </p>
 <strong>Fields:</strong>
 <ul>
@@ -35,21 +35,52 @@
         instance or another Map/List implementation. Both are supported.
     </li>
     <li>
-        <code>file</code>:
-        Path to a file in the workspace to write to.
+        <code>file</code> <i>(optional)</i>:
+        Optional path to a file in the workspace to write to.
+        If provided, then <code>returnText</code> must be <code>false</code> or omitted.
+        It is required that either <code>file</code> is provided, or <code>returnText</code> is <code>true</code>.
     </li>
     <li>
 	<code>pretty</code> <i>(optional)</i>:
         Prettify the output with this number of spaces added to each level of indentation.
-    </li>	
+    </li>
+    <li>
+        <code>returnText</code> <i>(optional)</i>:
+        Return the JSON as a string instead of writing it to a file. Defaults to <code>false</code>.
+        If <code>true</code>, then <code>file</code> must not be provided.
+        It is required that either <code>file</code> is provided, or <code>returnText</code> is <code>true</code>.
+    </li>
 </ul>
 <p>
     <strong>Example:</strong><br/>
-    <code><pre>
-def input = readJSON file: 'myfile.json'
-//Do some manipulation
-writeJSON file: 'output.json', json: input
-// or pretty print it, indented with a configurable number of spaces
-writeJSON file: 'output.json', json: input, pretty: 4
-	</pre></code>
+    Writing to a file:
+    <code>
+        <pre>
+        def amap = ['something': 'my datas',
+                    'size': 3,
+                    'isEmpty': false]
+
+        writeJSON file: 'data.json', json: amap
+        def read = readJSON file: 'data.json'
+
+        assert read.something == 'my datas'
+        assert read.size == 3
+        assert read.isEmpty == false
+        </pre>
+    </code>
+    Writing to a string:
+    <code>
+        <pre>
+        def amap = ['something': 'my datas',
+                    'size': 3,
+                    'isEmpty': false]
+
+        String json = writeJSON returnText: true, json: amap
+        def read = readJSON text: yml
+
+        assert read.something == 'my datas'
+        assert read.size == 3
+        assert read.isEmpty == false
+        </pre>
+    </code>
 </p>

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/jenkins/NodesByLabelStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/jenkins/NodesByLabelStepTest.java
@@ -53,17 +53,23 @@ public class NodesByLabelStepTest {
     @Before
     public void setup() throws Exception {
         job = r.jenkins.createProject(WorkflowJob.class, "workflow");
-        r.createSlave("dummy1", "a", new EnvVars());
-        r.createSlave("dummy2", "a b", new EnvVars());
-        r.createSlave("dummy3", "a b c", new EnvVars());
-        DumbSlave slave = r.createSlave("dummy4", "a b c d", new EnvVars());
-        slave.toComputer().waitUntilOnline();
+
+        DumbSlave[] dummies = {
+            r.createSlave("dummy1", "a", new EnvVars()),
+            r.createSlave("dummy2", "a b", new EnvVars()),
+            r.createSlave("dummy3", "a b c", new EnvVars()),
+            r.createSlave("dummy4", "a b c d", new EnvVars()),
+        };
+        for (DumbSlave dummy : dummies) {
+            dummy.toComputer().waitUntilOnline();
+        }
+
         CLICommandInvoker command = new CLICommandInvoker(r, "disconnect-node");
         CLICommandInvoker.Result result = command
                 .authorizedTo(Computer.DISCONNECT, Jenkins.READ)
                 .invokeWithArgs("dummy4");
         assertThat(result, succeededSilently());
-        assertThat(slave.toComputer().isOffline(), equalTo(true));
+        assertThat(dummies[3].toComputer().isOffline(), equalTo(true));
     }
 
     @Test


### PR DESCRIPTION
Adds a `returnText` boolean parameter to `writeJSON` so it returns the json as a string rather than writing it to a file.