### PR TITLE
[JENKINS-62928] Zip step should test canonical paths

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepExecution.java
@@ -143,7 +143,7 @@ public class ZipStepExecution extends SynchronousNonBlockingStepExecution<Void> 
             try {
                 for (String path : scanner.getIncludedFiles()) {
                     File toArchive = new File(dir, path).getCanonicalFile();
-                    if (!toArchive.getPath().equals(canonicalZip)) {
+                    if (!Files.isSameFile(toArchive.toPath(), p)) {
                         archiver.visit(toArchive, path);
                     }
                 }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepExecution.java
@@ -130,9 +130,9 @@ public class ZipStepExecution extends SynchronousNonBlockingStepExecution<Void> 
 
         @Override
         public Integer invoke(File dir, VirtualChannel channel) throws IOException, InterruptedException {
-            String canonicalZip = zipFile.getRemote();
+            String zipFileRemotePath = zipFile.getRemote();
 
-            Path p = Paths.get(canonicalZip);
+            Path p = Paths.get(zipFileRemotePath);
             if (overwrite && Files.exists(p)) {
                 Files.delete(p); //Will throw exception if it fails to delete it
             }
@@ -143,7 +143,7 @@ public class ZipStepExecution extends SynchronousNonBlockingStepExecution<Void> 
             try {
                 for (String path : scanner.getIncludedFiles()) {
                     File toArchive = new File(dir, path).getCanonicalFile();
-                    if (!Files.isSameFile(toArchive.toPath(), p)) {
+                    if (!toArchive.getPath().equals(zipFileRemotePath)) {
                         archiver.visit(toArchive, path);
                     }
                 }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepExecution.java
@@ -143,7 +143,7 @@ public class ZipStepExecution extends SynchronousNonBlockingStepExecution<Void> 
             try {
                 for (String path : scanner.getIncludedFiles()) {
                     File toArchive = new File(dir, path).getCanonicalFile();
-                    if (!toArchive.getPath().equals(zipFileRemotePath)) {
+                    if (!Files.isSameFile(toArchive.toPath(), p)) {
                         archiver.visit(toArchive, path);
                     }
                 }


### PR DESCRIPTION
[JENKINS-62928](https://issues.jenkins.io/browse/JENKINS-62928) Zip step hangs as it tries to recursively zip the archive being created. That seems to be caused by https://github.com/jenkinsci/pipeline-utility-steps-plugin/commit/c093b94d2ef3dc7f8b2329d397f7ca3cc27664a7. We do not compare canonical paths anymore, which causes the zip step to consider the zip it is currently creating: the process hangs and produces a very big corrupted zip file.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
