### PR TITLE
add one param to set charset when read Properties file

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep.java
@@ -26,7 +26,6 @@ package org.jenkinsci.plugins.pipeline.utility.steps.conf;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
-import hudson.Util;
 import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStep;
 import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -44,7 +43,7 @@ import java.util.Map;
 public class ReadPropertiesStep extends AbstractFileOrTextStep {
     private Map<Object, Object> defaults;
     private boolean interpolate;
-    private String encoding;
+    private String charset;
 
     @DataBoundConstructor
     public ReadPropertiesStep() {
@@ -95,13 +94,17 @@ public class ReadPropertiesStep extends AbstractFileOrTextStep {
         this.interpolate = interpolate;
     }
 
-    public String getEncoding() {
-        return encoding;
+    public String getCharset() {
+        return charset;
     }
 
+    /**
+     * The charset encoding to use when read the properties file. Defaults to ISO 8859-1 .
+     * @param charset the charset
+     */
     @DataBoundSetter
-    public void setEncoding(String encoding) {
-        this.encoding = Util.fixEmptyAndTrim(encoding);
+    public void setCharset(String charset) {
+        this.charset = charset;
     }
 
     @Extension

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep.java
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.pipeline.utility.steps.conf;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import hudson.Util;
 import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStep;
 import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -43,6 +44,7 @@ import java.util.Map;
 public class ReadPropertiesStep extends AbstractFileOrTextStep {
     private Map<Object, Object> defaults;
     private boolean interpolate;
+    private String encoding;
 
     @DataBoundConstructor
     public ReadPropertiesStep() {
@@ -91,6 +93,15 @@ public class ReadPropertiesStep extends AbstractFileOrTextStep {
     @DataBoundSetter
     public void setInterpolate(Boolean interpolate) {
         this.interpolate = interpolate;
+    }
+
+    public String getEncoding() {
+        return encoding;
+    }
+
+    @DataBoundSetter
+    public void setEncoding(String encoding) {
+        this.encoding = Util.fixEmptyAndTrim(encoding);
     }
 
     @Extension

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
@@ -42,6 +42,8 @@ import org.jenkinsci.plugins.workflow.steps.StepContext;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.io.StringReader;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -84,7 +86,11 @@ public class ReadPropertiesStepExecution extends AbstractFileOrTextStepExecution
             FilePath f = ws.child(step.getFile());
             if (f.exists() && !f.isDirectory()) {
                 try(InputStream is = f.read()){
-                   properties.load(is);
+                    if(StringUtils.isEmpty(step.getEncoding())){
+                        properties.load(is);
+                    } else {
+                        properties.load( new BufferedReader(new InputStreamReader(is, step.getEncoding())));
+                    }
                 }
             } else if (f.isDirectory()) {
                 logger.print("warning: ");

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
@@ -86,11 +86,10 @@ public class ReadPropertiesStepExecution extends AbstractFileOrTextStepExecution
             FilePath f = ws.child(step.getFile());
             if (f.exists() && !f.isDirectory()) {
                 try(InputStream is = f.read()){
-                    if(StringUtils.isEmpty(step.getEncoding())){
+                    if (StringUtils.isEmpty(step.getCharset())) {
                         properties.load(is);
                     } else {
-                        try(InputStreamReader isr = new InputStreamReader(is, step.getEncoding());
-                            BufferedReader br = new BufferedReader(isr)) {
+                        try (InputStreamReader isr = new InputStreamReader(is, step.getCharset()); BufferedReader br = new BufferedReader(isr)) {
                             properties.load(br);
                         }
                     }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
@@ -89,7 +89,10 @@ public class ReadPropertiesStepExecution extends AbstractFileOrTextStepExecution
                     if(StringUtils.isEmpty(step.getEncoding())){
                         properties.load(is);
                     } else {
-                        properties.load( new BufferedReader(new InputStreamReader(is, step.getEncoding())));
+                        try(InputStreamReader isr = new InputStreamReader(is, step.getEncoding());
+                            BufferedReader br = new BufferedReader(isr)) {
+                            properties.load(br);
+                        }
                     }
                 }
             } else if (f.isDirectory()) {

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep/config.jelly
@@ -24,7 +24,13 @@
   -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <f:block>
-        <p>This is a special step. No snippet generation available. See inline help for more information.</p>
-    </f:block>
+    <f:entry title="${%file.title}" field="file" description="${%file.description}">
+        <f:textbox />
+    </f:entry>
+    <f:entry title="${%text.title}" field="text" description="${%text.description}">
+        <f:textbox />
+    </f:entry>
+    <f:entry title="${%interpolate.title}" field="interpolate" description="${%interpolate.description}">
+        <f:checkbox />
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep/config.jelly
@@ -33,4 +33,7 @@
     <f:entry title="${%interpolate.title}" field="interpolate" description="${%interpolate.description}">
         <f:checkbox />
     </f:entry>
+    <f:entry title="${%charset.title}" field="charset" description="${%charset.description}">
+        <f:textbox />
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep/config.properties
@@ -1,0 +1,7 @@
+file.title=File
+file.description=(Optional) path to a file in the workspace to read the properties from
+text.title=Text
+text.description=An Optional String containing properties formatted data
+
+interpolate.title=Interpolate
+interpolate.description=Flag to indicate if the properties should be interpolated or not.

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep/config.properties
@@ -2,6 +2,7 @@ file.title=File
 file.description=(Optional) path to a file in the workspace to read the properties from
 text.title=Text
 text.description=An Optional String containing properties formatted data
-
 interpolate.title=Interpolate
 interpolate.description=Flag to indicate if the properties should be interpolated or not.
+charset.title=Charset
+charset.description=(Optional) What charset to use when read the properties file. Default is empty, then will use jvm ISO 8859-1.

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep/help.html
@@ -59,6 +59,10 @@
 
         In case of error or cyclic dependencies, the original properties will be returned.
     </li>
+    <li>
+        <code>charset</code>:
+        What charset to use when read properties file. Default is empty, then will use jvm ISO 8859-1.
+    </li>
 </ul>
 <p>
     <strong>Example:</strong><br/>
@@ -80,6 +84,12 @@
         assert props.resource = 'README.txt'
         // if fullUrl is defined to ${url}/${resource} then it should evaluate to http://localhost/README.txt
         assert props.fullUrl = 'http://localhost/README.txt'
+        </pre>
+    </code>
+    <strong>Example with charset:</strong>
+    <code>
+        <pre>
+        def props = readProperties charset: 'UTF-8', file: 'test.properties'
         </pre>
     </code>
 </p>

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepTest.java
@@ -115,6 +115,30 @@ public class ReadPropertiesStepTest {
     }
 
     @Test
+    public void readFileWithCharset() throws Exception {
+        Properties props = new Properties();
+        props.setProperty("test", "One");
+        props.setProperty("another", "Two");
+        props.setProperty("zh", "中文");
+        File file = temp.newFile();
+        try (FileWriter f = new FileWriter(file)) {
+            props.store(f, "Pipeline test");
+        }
+
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node('slaves') {\n" +
+                        "  def props = readProperties charset: 'utf-8', file: '" + separatorsToSystemEscaped(file.getAbsolutePath()) + "'\n" +
+                        "  assert props['test'] == 'One'\n" +
+                        "  assert props['another'] == 'Two'\n" +
+                        "  assert props.test == 'One'\n" +
+                        "  assert props.another == 'Two'\n" +
+                        "  assert props.zh == '中文' \n" +
+                        "}", true));
+        j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    }
+
+    @Test
     public void readText() throws Exception {
         Properties props = new Properties();
         props.setProperty("test", "One");


### PR DESCRIPTION
Signed-off-by: bright.ma RMSH06 <bright.ma@blackshark.com>

<!-- Please describe your pull request here. -->

add one param to set  charset  when read Properties file 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
