### PR TITLE
allow writeYaml and writeJSON to return text without requiring a node

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStep.java
@@ -223,7 +223,7 @@ public class WriteYamlStep extends Step {
 
         @Override
         public Set<? extends Class<?>> getRequiredContext() {
-            return ImmutableSet.of(TaskListener.class, FilePath.class);
+            return ImmutableSet.of(TaskListener.class);
         }
 
         @Override
@@ -283,7 +283,9 @@ public class WriteYamlStep extends Step {
         @Override
         protected Void run () throws Exception {
             FilePath ws = getContext().get(FilePath.class);
-            assert ws != null;
+            if (ws == null) {
+                throw new MissingContextVariableException(FilePath.class);
+            }
             FilePath path = ws.child(step.getFile());
             if (path.isDirectory()) {
                 throw new FileNotFoundException(path.getRemote() + " is a directory.");

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStep.java
@@ -153,7 +153,7 @@ public class WriteJSONStep extends Step {
 
         @Override
         public Set<? extends Class<?>> getRequiredContext() {
-            return ImmutableSet.of(TaskListener.class, FilePath.class);
+            return ImmutableSet.of(TaskListener.class);
         }
 
         @Override

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStepExecution.java
@@ -25,6 +25,7 @@
 package org.jenkinsci.plugins.pipeline.utility.steps.json;
 
 import hudson.FilePath;
+import org.jenkinsci.plugins.workflow.steps.MissingContextVariableException;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 
@@ -50,6 +51,9 @@ public class WriteJSONStepExecution extends SynchronousNonBlockingStepExecution<
     @Override
     protected Void run() throws Exception {
         FilePath ws = getContext().get(FilePath.class);
+        if (ws == null) {
+            throw new MissingContextVariableException(FilePath.class);
+        }
         assert ws != null;
 
         FilePath path = ws.child(step.getFile());

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStepTest.java
@@ -37,31 +37,31 @@ public class WriteYamlStepTest {
         WorkflowRun b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
-	@Test
-	public void writeArbitraryObject() throws Exception {
-		WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-		p.setDefinition(new CpsFlowDefinition(
+        @Test
+        public void writeArbitraryObject() throws Exception {
+                WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+                p.setDefinition(new CpsFlowDefinition(
                  "def l = [] \n" +
                         "node('slaves') {\n" +
-						"   writeYaml file: 'test', data: new Date() \n" +
+                                                "   writeYaml file: 'test', data: new Date() \n" +
                          "  def yml = readYaml file: 'test' \n" +
                          "  assert yml =~ /2\\d{3}/ \n" +
-						"}",
-				true));
+                                                "}",
+                                true));
         WorkflowRun b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
-	}
+        }
 
     @Test
     public void writeMapObject() throws Exception {
-		WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "map");
-		p.setDefinition(new CpsFlowDefinition(
-				  "node('slaves') {\n" +
-						 "  writeYaml file: 'test', data: ['a': 1, 'b': 2] \n" +
+                WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "map");
+                p.setDefinition(new CpsFlowDefinition(
+                                  "node('slaves') {\n" +
+                                                 "  writeYaml file: 'test', data: ['a': 1, 'b': 2] \n" +
                          "  def yml = readYaml file: 'test' \n" +
                          "  assert yml == ['a' : 1, 'b': 2] \n" +
-						 "}",
-				true));
-		WorkflowRun b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+                                                 "}",
+                                true));
+                WorkflowRun b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
@@ -221,14 +221,25 @@ public class WriteYamlStepTest {
 
     @Test
     public void returnText() throws Exception {
-		WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "map");
-		p.setDefinition(new CpsFlowDefinition(
-				  "node('slaves') {\n" +
-						 "  String written = writeYaml returnText: true, data: ['a': 1, 'b': 2] \n" +
-                         "  def yml = readYaml text: written \n" +
-                         "  assert yml == ['a' : 1, 'b': 2] \n" +
-						 "}",
-				true));
-		WorkflowRun b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+                WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "map");
+                p.setDefinition(new CpsFlowDefinition(
+                "node('slaves') {\n" +
+                        "  String written = writeYaml returnText: true, data: ['a': 1, 'b': 2] \n" +
+                        "  def yml = readYaml text: written \n" +
+                        "  assert yml == ['a' : 1, 'b': 2] \n" +
+                        "}",
+                true));
+        WorkflowRun b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    }
+
+    @Test
+    public void returnTextWithoutNode() throws Exception {
+                WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "map");
+                p.setDefinition(new CpsFlowDefinition(
+                "String written = writeYaml returnText: true, data: ['a': 1, 'b': 2] \n" +
+                "def yml = readYaml text: written \n" +
+                "assert yml == ['a' : 1, 'b': 2] \n",
+                true));
+        WorkflowRun b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStepTest.java
@@ -131,15 +131,26 @@ public class WriteJSONStepTest {
 
     @Test
     public void returnText() throws Exception {
-		WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-		p.setDefinition(new CpsFlowDefinition(
-				  "node {\n" +
-						 "  String written = writeJSON returnText: true, json: ['a': 1, 'b': 2] \n" +
-                         "  def json = readJSON text: written, returnPojo: true \n" +
-                         "  assert json == ['a': 1, 'b': 2] \n" +
-						 "}",
-				true));
-		j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node {\n" +
+                        "  String written = writeJSON returnText: true, json: ['a': 1, 'b': 2] \n" +
+                        "  def json = readJSON text: written, returnPojo: true \n" +
+                        "  assert json == ['a': 1, 'b': 2] \n" +
+                        "}",
+                true));
+        j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    }
+
+    @Test
+    public void returnTextWithoutNode() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "String written = writeJSON returnText: true, json: ['a': 1, 'b': 2] \n" +
+                "def json = readJSON text: written, returnPojo: true \n" +
+                "assert json == ['a': 1, 'b': 2] \n",
+                true));
+        j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test


### PR DESCRIPTION
Allow `writeYaml` and `writeJSON` to run with `returnText: true` without requiring a node. This is the same way that `readYaml` and `readJSON` work when using the `text` parameter.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
