### PR TITLE
Replace JSR-305 annotations

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/AbstractFileOrTextStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/AbstractFileOrTextStepExecution.java
@@ -1,11 +1,11 @@
 package org.jenkinsci.plugins.pipeline.utility.steps;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.FilePath;
 import org.jenkinsci.plugins.workflow.steps.MissingContextVariableException;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 
-import javax.annotation.Nonnull;
 
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 
@@ -15,7 +15,7 @@ public abstract class AbstractFileOrTextStepExecution<T> extends SynchronousNonB
 
     protected FilePath ws;
 
-    protected AbstractFileOrTextStepExecution(@Nonnull AbstractFileOrTextStep step, @Nonnull StepContext context) {
+    protected AbstractFileOrTextStepExecution(@NonNull AbstractFileOrTextStep step, @NonNull StepContext context) {
         super(context);
         this.fileOrTextStep = step;
     }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/CompareVersionsStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/CompareVersionsStep.java
@@ -23,6 +23,7 @@
  */
 package org.jenkinsci.plugins.pipeline.utility.steps;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.AbortException;
 import hudson.Extension;
 import hudson.util.VersionNumber;
@@ -34,7 +35,6 @@ import org.jenkinsci.plugins.workflow.steps.SynchronousStepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.Set;
 
@@ -85,7 +85,7 @@ public class CompareVersionsStep extends Step {
         private final String v2;
         private final boolean failIfEmpty;
 
-        protected ExecutionImpl(@Nonnull final StepContext context, final String v1, final String v2, final boolean failIfEmpty) {
+        protected ExecutionImpl(@NonNull final StepContext context, final String v1, final String v2, final boolean failIfEmpty) {
             super(context);
             this.v1 = v1;
             this.v2 = v2;
@@ -131,7 +131,7 @@ public class CompareVersionsStep extends Step {
             return "compareVersions";
         }
 
-        @Nonnull
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.CompareVersionsStep_DisplayName();

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStep.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.pipeline.utility.steps.conf;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStep;
 import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStepDescriptorImpl;
@@ -32,7 +33,6 @@ import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
 import java.util.Map;
 
 /**
@@ -105,7 +105,7 @@ public class ReadPropertiesStep extends AbstractFileOrTextStep {
         }
 
         @Override
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "Read properties from files in the workspace or text.";
         }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.pipeline.utility.steps.conf;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.FilePath;
 import hudson.model.TaskListener;
 import org.apache.commons.configuration2.AbstractConfiguration;
@@ -33,7 +34,6 @@ import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStepExecution;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 
-import javax.annotation.Nonnull;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.io.StringReader;
@@ -52,7 +52,7 @@ public class ReadPropertiesStepExecution extends AbstractFileOrTextStepExecution
 
     private transient ReadPropertiesStep step;
 
-    protected ReadPropertiesStepExecution(@Nonnull ReadPropertiesStep step, @Nonnull StepContext context) {
+    protected ReadPropertiesStepExecution(@NonNull ReadPropertiesStep step, @NonNull StepContext context) {
         super(step, context);
         this.step = step;
     }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadYamlStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadYamlStep.java
@@ -33,8 +33,7 @@ import java.io.Reader;
 import java.util.LinkedList;
 import java.util.List;
 
-import javax.annotation.Nonnull;
-
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStep;
 import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStepDescriptorImpl;
@@ -77,7 +76,7 @@ public class ReadYamlStep extends AbstractFileOrTextStep {
 		}
 
 		@Override
-		@Nonnull
+		@NonNull
 		public String getDisplayName() {
 			return "Read yaml from files in the workspace or text.";
 		}
@@ -87,7 +86,7 @@ public class ReadYamlStep extends AbstractFileOrTextStep {
 		private static final long serialVersionUID = 1L;
 		private transient ReadYamlStep step;
 
-		protected Execution(@Nonnull ReadYamlStep step, @Nonnull StepContext context) {
+		protected Execution(@NonNull ReadYamlStep step, @NonNull StepContext context) {
 			super(step, context);
 			this.step = step;
 		}

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStep.java
@@ -25,6 +25,7 @@
 package org.jenkinsci.plugins.pipeline.utility.steps.conf;
 
 import com.google.common.collect.ImmutableSet;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.TaskListener;
@@ -35,7 +36,6 @@ import org.jenkinsci.plugins.workflow.steps.*;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
 import java.io.*;
 import java.net.URL;
 import java.nio.charset.Charset;
@@ -232,7 +232,7 @@ public class WriteYamlStep extends Step {
         }
 
         @Override
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "Write a yaml from an object or objects.";
         }
@@ -243,7 +243,7 @@ public class WriteYamlStep extends Step {
 
         private transient WriteYamlStep step;
 
-        protected ReturnTextExecution(@Nonnull StepContext context, WriteYamlStep step) {
+        protected ReturnTextExecution(@NonNull StepContext context, WriteYamlStep step) {
             super(context);
             this.step = step;
         }
@@ -275,7 +275,7 @@ public class WriteYamlStep extends Step {
 
         private transient WriteYamlStep step;
 
-        protected Execution(@Nonnull StepContext context, WriteYamlStep step) {
+        protected Execution(@NonNull StepContext context, WriteYamlStep step) {
             super(context);
             this.step = step;
         }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/mf/ReadManifestStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/mf/ReadManifestStep.java
@@ -24,14 +24,13 @@
 
 package org.jenkinsci.plugins.pipeline.utility.steps.conf.mf;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStep;
 import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
-
-import javax.annotation.Nonnull;
 
 /**
  * Reads a Jar Manifest.
@@ -65,7 +64,7 @@ public class ReadManifestStep extends AbstractFileOrTextStep {
         }
 
         @Override
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "Read a Jar Manifest";
         }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/mf/ReadManifestStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/mf/ReadManifestStepExecution.java
@@ -24,14 +24,13 @@
 
 package org.jenkinsci.plugins.pipeline.utility.steps.conf.mf;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.FilePath;
 import hudson.model.TaskListener;
 import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStepExecution;
 import org.jenkinsci.plugins.pipeline.utility.steps.zip.UnZipStepExecution;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
-
-import javax.annotation.Nonnull;
 
 import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
@@ -52,7 +51,7 @@ public class ReadManifestStepExecution extends AbstractFileOrTextStepExecution<S
 
     private transient ReadManifestStep step;
 
-    protected ReadManifestStepExecution(@Nonnull ReadManifestStep step, @Nonnull StepContext context) {
+    protected ReadManifestStepExecution(@NonNull ReadManifestStep step, @NonNull StepContext context) {
         super(step, context);
         this.step = step;
     }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/csv/ReadCSVStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/csv/ReadCSVStep.java
@@ -23,13 +23,13 @@
  */
 package org.jenkinsci.plugins.pipeline.utility.steps.csv;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
 import hudson.Extension;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import javax.annotation.Nonnull;
 import org.codehaus.groovy.control.customizers.ImportCustomizer;
 import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStep;
 import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStepDescriptorImpl;
@@ -82,7 +82,7 @@ public class ReadCSVStep extends AbstractFileOrTextStep {
         }
 
         @Override
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return Messages.ReadCSVStep_DescriptorImpl_displayName();
         }
@@ -136,12 +136,12 @@ public class ReadCSVStep extends AbstractFileOrTextStep {
         }
 
         @Override
-        public boolean permitsConstructor(@Nonnull Constructor<?> constructor, @Nonnull Object[] args) {
+        public boolean permitsConstructor(@NonNull Constructor<?> constructor, @NonNull Object[] args) {
             return false;
         }
 
         @Override
-        public boolean permitsStaticMethod(@Nonnull Method method, @Nonnull Object[] args) {
+        public boolean permitsStaticMethod(@NonNull Method method, @NonNull Object[] args) {
             final Class<?> aClass = method.getDeclaringClass();
             final Package aPackage = aClass.getPackage();
 
@@ -161,17 +161,17 @@ public class ReadCSVStep extends AbstractFileOrTextStep {
         }
 
         @Override
-        public boolean permitsFieldGet(@Nonnull Field field, @Nonnull Object receiver) {
+        public boolean permitsFieldGet(@NonNull Field field, @NonNull Object receiver) {
             return false;
         }
 
         @Override
-        public boolean permitsFieldSet(@Nonnull Field field, @Nonnull Object receiver, Object value) {
+        public boolean permitsFieldSet(@NonNull Field field, @NonNull Object receiver, Object value) {
             return false;
         }
 
         @Override
-        public boolean permitsStaticFieldGet(@Nonnull Field field) {
+        public boolean permitsStaticFieldGet(@NonNull Field field) {
             final Class<?> aClass = field.getDeclaringClass();
             final Package aPackage = aClass.getPackage();
 
@@ -187,7 +187,7 @@ public class ReadCSVStep extends AbstractFileOrTextStep {
         }
 
         @Override
-        public boolean permitsStaticFieldSet(@Nonnull Field field, Object value) {
+        public boolean permitsStaticFieldSet(@NonNull Field field, Object value) {
             return false;
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/csv/ReadCSVStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/csv/ReadCSVStepExecution.java
@@ -23,6 +23,7 @@
  */
 package org.jenkinsci.plugins.pipeline.utility.steps.csv;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.FilePath;
 
 import java.io.IOException;
@@ -32,7 +33,6 @@ import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.Nonnull;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
@@ -51,7 +51,7 @@ public class ReadCSVStepExecution extends AbstractFileOrTextStepExecution<List<C
 
     private final transient ReadCSVStep step;
 
-    protected ReadCSVStepExecution(@Nonnull ReadCSVStep step, @Nonnull StepContext context) {
+    protected ReadCSVStepExecution(@NonNull ReadCSVStep step, @NonNull StepContext context) {
         super(step, context);
         this.step = step;
     }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/csv/WriteCSVStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/csv/WriteCSVStep.java
@@ -24,13 +24,13 @@
 package org.jenkinsci.plugins.pipeline.utility.steps.csv;
 
 import com.google.common.collect.ImmutableSet;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.commons.csv.CSVFormat;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Util;
 import hudson.model.TaskListener;
 import java.util.Set;
-import javax.annotation.Nonnull;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
@@ -95,7 +95,7 @@ public class WriteCSVStep extends Step {
         }
 
         @Override
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return Messages.WriteCSVStep_DescriptorImpl_displayName();
         }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/csv/WriteCSVStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/csv/WriteCSVStepExecution.java
@@ -23,12 +23,12 @@
  */
 package org.jenkinsci.plugins.pipeline.utility.steps.csv;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import hudson.FilePath;
 import java.io.FileNotFoundException;
 import java.io.OutputStreamWriter;
-import javax.annotation.Nonnull;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
@@ -42,7 +42,7 @@ public class WriteCSVStepExecution extends SynchronousNonBlockingStepExecution<V
 
     private final transient WriteCSVStep step;
 
-    protected WriteCSVStepExecution(@Nonnull WriteCSVStep step, @Nonnull StepContext context) {
+    protected WriteCSVStepExecution(@NonNull WriteCSVStep step, @NonNull StepContext context) {
         super(context);
         this.step = step;
     }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileHashStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileHashStep.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.pipeline.utility.steps.fs;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.FilePath;
 import hudson.model.Descriptor;
 import hudson.remoting.VirtualChannel;
@@ -13,7 +14,6 @@ import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 import org.kohsuke.stapler.QueryParameter;
 
-import javax.annotation.Nonnull;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -33,7 +33,7 @@ public abstract class FileHashStep extends Step {
     private final String file;
     private final String hashAlgorithm;
 
-    public FileHashStep(String file, @Nonnull String hashAlgorithm) throws Descriptor.FormException {
+    public FileHashStep(String file, @NonNull String hashAlgorithm) throws Descriptor.FormException {
         if (StringUtils.isBlank(file)) {
             throw new Descriptor.FormException("can't be blank", "file");
         }
@@ -73,7 +73,7 @@ public abstract class FileHashStep extends Step {
         }
 
         @Override
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "Compute the " + algorithm.toUpperCase(Locale.ENGLISH) + " of a given file";
         }
@@ -92,7 +92,7 @@ public abstract class FileHashStep extends Step {
         private static final long serialVersionUID = 1L;
         private transient final FileHashStep step;
 
-        protected ExecutionImpl(@Nonnull FileHashStep step, @Nonnull StepContext context) {
+        protected ExecutionImpl(@NonNull FileHashStep step, @NonNull StepContext context) {
             super(context);
             this.step = step;
         }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileWrapper.java
@@ -24,10 +24,10 @@
 
 package org.jenkinsci.plugins.pipeline.utility.steps.fs;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.FilePath;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.Serializable;
 
@@ -39,15 +39,15 @@ import java.io.Serializable;
 public class FileWrapper implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    @Nonnull
+    @NonNull
     private final String name;
-    @Nonnull
+    @NonNull
     private final String path;
     private final boolean directory;
     private final long length;
     private final long lastModified;
 
-    public FileWrapper(@Nonnull String name, @Nonnull String path, boolean directory, long length, long lastModified) {
+    public FileWrapper(@NonNull String name, @NonNull String path, boolean directory, long length, long lastModified) {
         this.name = name;
         this.directory = directory;
         this.length = length;
@@ -59,7 +59,7 @@ public class FileWrapper implements Serializable {
         }
     }
 
-    protected FileWrapper(@Nonnull FilePath base, @Nonnull FilePath file) throws IOException, InterruptedException {
+    protected FileWrapper(@NonNull FilePath base, @NonNull FilePath file) throws IOException, InterruptedException {
         this(file.getName(),
                 file.getRemote().substring(base.getRemote().length() + 1),
                 file.isDirectory(),
@@ -67,16 +67,16 @@ public class FileWrapper implements Serializable {
                 file.lastModified());
     }
 
-    protected FileWrapper(@Nonnull FilePath file) throws IOException, InterruptedException {
+    protected FileWrapper(@NonNull FilePath file) throws IOException, InterruptedException {
         this(file.getName(), file.getRemote(), file.isDirectory(), file.length(), file.lastModified());
     }
 
-    @Whitelisted @Nonnull
+    @Whitelisted @NonNull
     public String getName() {
         return name;
     }
 
-    @Whitelisted @Nonnull
+    @Whitelisted @NonNull
     public String getPath() {
         return path;
     }
@@ -96,7 +96,7 @@ public class FileWrapper implements Serializable {
         return lastModified;
     }
 
-    @Override @Whitelisted @Nonnull
+    @Override @Whitelisted @NonNull
     public String toString() {
         return getPath();
     }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FindFilesStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FindFilesStepExecution.java
@@ -24,12 +24,12 @@
 
 package org.jenkinsci.plugins.pipeline.utility.steps.fs;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.FilePath;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 
-import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import java.util.Arrays;
 import java.util.List;
@@ -45,7 +45,7 @@ public class FindFilesStepExecution extends SynchronousNonBlockingStepExecution<
     @Inject
     private transient FindFilesStep step;
 
-    protected FindFilesStepExecution(@Nonnull StepContext context, FindFilesStep step) {
+    protected FindFilesStepExecution(@NonNull StepContext context, FindFilesStep step) {
         super(context);
         this.step = step;
     }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/TouchStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/TouchStep.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.pipeline.utility.steps.fs;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.Descriptor;
@@ -38,7 +39,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
-import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.Set;
 
@@ -132,7 +132,7 @@ public class TouchStep extends Step {
 
         private transient TouchStep step;
 
-        protected ExecutionImpl(@Nonnull TouchStep step, @Nonnull StepContext context) {
+        protected ExecutionImpl(@NonNull TouchStep step, @NonNull StepContext context) {
             super(context);
             this.step = step;
         }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStep.java
@@ -23,6 +23,7 @@
  */
 package org.jenkinsci.plugins.pipeline.utility.steps.json;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStep;
 import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStepDescriptorImpl;
@@ -30,8 +31,6 @@ import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
-
-import javax.annotation.Nonnull;
 
 /**
  * Reads a JSON file from the workspace.
@@ -64,7 +63,7 @@ public class ReadJSONStep extends AbstractFileOrTextStep {
         }
 
         @Override
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return Messages.ReadJSONStep_DescriptorImpl_displayName();
         }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStepExecution.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.pipeline.utility.steps.json;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.FilePath;
 import net.sf.json.JSON;
 import net.sf.json.JSONArray;
@@ -35,7 +36,6 @@ import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.pipeline.utility.steps.AbstractFileOrTextStepExecution;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 
-import javax.annotation.Nonnull;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -57,7 +57,7 @@ public class ReadJSONStepExecution extends AbstractFileOrTextStepExecution<Objec
 
     private transient ReadJSONStep step;
 
-    protected ReadJSONStepExecution(@Nonnull ReadJSONStep step, @Nonnull StepContext context) {
+    protected ReadJSONStepExecution(@NonNull ReadJSONStep step, @NonNull StepContext context) {
         super(step, context);
         this.step = step;
     }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStep.java
@@ -24,6 +24,7 @@
 package org.jenkinsci.plugins.pipeline.utility.steps.json;
 
 import com.google.common.collect.ImmutableSet;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.TaskListener;
@@ -37,7 +38,6 @@ import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Set;
@@ -161,7 +161,7 @@ public class WriteJSONStep extends Step {
         }
 
         @Override
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return Messages.WriteJSONStep_DescriptorImpl_displayName();
         }
@@ -188,7 +188,7 @@ public class WriteJSONStep extends Step {
 
         private transient WriteJSONStep step;
 
-        protected ReturnTextExecution(WriteJSONStep step, @Nonnull StepContext context) {
+        protected ReturnTextExecution(WriteJSONStep step, @NonNull StepContext context) {
             super(context);
             this.step = step;
         }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStepExecution.java
@@ -24,12 +24,12 @@
 
 package org.jenkinsci.plugins.pipeline.utility.steps.json;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.FilePath;
 import org.jenkinsci.plugins.workflow.steps.MissingContextVariableException;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 
-import javax.annotation.Nonnull;
 import java.io.FileNotFoundException;
 import java.io.OutputStreamWriter;
 
@@ -43,7 +43,7 @@ public class WriteJSONStepExecution extends SynchronousNonBlockingStepExecution<
 
     private transient WriteJSONStep step;
 
-    protected WriteJSONStepExecution(@Nonnull WriteJSONStep step, @Nonnull StepContext context) {
+    protected WriteJSONStepExecution(@NonNull WriteJSONStep step, @NonNull StepContext context) {
         super(context);
         this.step = step;
     }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/maven/ReadMavenPomStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/maven/ReadMavenPomStep.java
@@ -25,6 +25,7 @@
 package org.jenkinsci.plugins.pipeline.utility.steps.maven;
 
 import com.google.common.collect.ImmutableSet;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.TaskListener;
@@ -43,7 +44,6 @@ import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.lang.reflect.Constructor;
@@ -109,7 +109,7 @@ public class ReadMavenPomStep extends Step {
         }
 
         @Override
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "Read a maven project file.";
         }
@@ -120,7 +120,7 @@ public class ReadMavenPomStep extends Step {
 
         private transient ReadMavenPomStep step;
 
-        protected Execution(@Nonnull ReadMavenPomStep step, @Nonnull StepContext context) {
+        protected Execution(@NonNull ReadMavenPomStep step, @NonNull StepContext context) {
             super(context);
             this.step = step;
         }
@@ -190,7 +190,7 @@ public class ReadMavenPomStep extends Step {
         }
 
         @Override
-        public boolean permitsConstructor(@Nonnull Constructor<?> constructor, @Nonnull Object[] args) {
+        public boolean permitsConstructor(@NonNull Constructor<?> constructor, @NonNull Object[] args) {
             if (constructor == null) {
                 return false;
             }
@@ -205,12 +205,12 @@ public class ReadMavenPomStep extends Step {
         }
 
         @Override
-        public boolean permitsStaticMethod(@Nonnull Method method, @Nonnull Object[] args) {
+        public boolean permitsStaticMethod(@NonNull Method method, @NonNull Object[] args) {
             return false;
         }
 
         @Override
-        public boolean permitsFieldGet(@Nonnull Field field, @Nonnull Object receiver) {
+        public boolean permitsFieldGet(@NonNull Field field, @NonNull Object receiver) {
 
             if (receiver == null) {
                 return false;
@@ -226,7 +226,7 @@ public class ReadMavenPomStep extends Step {
         }
 
         @Override
-        public boolean permitsFieldSet(@Nonnull Field field, @Nonnull Object receiver, Object value) {
+        public boolean permitsFieldSet(@NonNull Field field, @NonNull Object receiver, Object value) {
 
             if (receiver == null) {
                 return false;
@@ -241,12 +241,12 @@ public class ReadMavenPomStep extends Step {
         }
 
         @Override
-        public boolean permitsStaticFieldGet(@Nonnull Field field) {
+        public boolean permitsStaticFieldGet(@NonNull Field field) {
             return false;
         }
 
         @Override
-        public boolean permitsStaticFieldSet(@Nonnull Field field, Object value) {
+        public boolean permitsStaticFieldSet(@NonNull Field field, Object value) {
             return false;
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/maven/WriteMavenPomStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/maven/WriteMavenPomStep.java
@@ -24,6 +24,8 @@
 
 package org.jenkinsci.plugins.pipeline.utility.steps.maven;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.AbortException;
 import hudson.Extension;
 import hudson.FilePath;
@@ -38,8 +40,6 @@ import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
 import java.io.FileNotFoundException;
 import java.io.OutputStream;
 import java.util.Collections;
@@ -111,7 +111,7 @@ public class WriteMavenPomStep extends Step {
         }
 
         @Override
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "Write a maven project file.";
         }
@@ -122,7 +122,7 @@ public class WriteMavenPomStep extends Step {
 
         private transient WriteMavenPomStep step;
 
-        protected Execution(@Nonnull WriteMavenPomStep step, @Nonnull StepContext context) {
+        protected Execution(@NonNull WriteMavenPomStep step, @NonNull StepContext context) {
             super(context);
             this.step = step;
         }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStep.java
@@ -25,6 +25,7 @@
 package org.jenkinsci.plugins.pipeline.utility.steps.zip;
 
 import com.google.common.collect.ImmutableSet;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.Descriptor;
@@ -37,7 +38,6 @@ import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
 import java.util.Set;
 
 /**
@@ -237,7 +237,7 @@ public class UnZipStep extends Step {
         }
 
         @Override
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "Extract Zip file";
         }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStepExecution.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.pipeline.utility.steps.zip;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.FilePath;
 import hudson.model.TaskListener;
 import hudson.remoting.VirtualChannel;
@@ -34,7 +35,6 @@ import org.apache.tools.ant.types.selectors.SelectorUtils;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 
-import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -60,7 +60,7 @@ public class UnZipStepExecution extends SynchronousNonBlockingStepExecution<Obje
 
     private transient UnZipStep step;
 
-    protected UnZipStepExecution(@Nonnull UnZipStep step, @Nonnull StepContext context) {
+    protected UnZipStepExecution(@NonNull UnZipStep step, @NonNull StepContext context) {
         super(context);
         this.step = step;
     }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepExecution.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.pipeline.utility.steps.zip;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
@@ -41,7 +42,6 @@ import org.jenkinsci.plugins.workflow.steps.MissingContextVariableException;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 
-import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -60,7 +60,7 @@ public class ZipStepExecution extends SynchronousNonBlockingStepExecution<Void> 
 
     private transient ZipStep step;
 
-    protected ZipStepExecution(@Nonnull ZipStep step, @Nonnull StepContext context) {
+    protected ZipStepExecution(@NonNull ZipStep step, @NonNull StepContext context) {
         super(context);
         this.step = step;
     }


### PR DESCRIPTION
Replaces the JSR-305 `@Nonnull` / `@CheckForNull` annotations (https://github.com/jenkinsci/jenkins/pull/4604).

ℹ️  The spotbugs annotations are marked as deprecated, but updating to a more recent Jenkins version should fix that (eg. #100).

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
