### PR TITLE
`argumentsToString` should never reflect `text: 'stuff'`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/AbstractFileOrTextStepDescriptorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/AbstractFileOrTextStepDescriptorImpl.java
@@ -27,4 +27,14 @@ public abstract class AbstractFileOrTextStepDescriptorImpl extends StepDescripto
         }
         return step;
     }
+
+    @Override
+    public String argumentsToString(Map<String, Object> namedArgs) {
+        if (namedArgs.keySet().equals(Collections.singleton("text"))) {
+            return null;
+        } else {
+            return super.argumentsToString(namedArgs);
+        }
+    }
+
 }


### PR DESCRIPTION
Supersedes #104. @bwalding @imonteroperez

Note that if you were bitten by this issue, you were probably writing your Pipeline script using poor practices to begin with. For example,

```groovy
def json = sh returnStdout: true, script: 'something-yielding-secret-JSON'
def object = readJSON text: json
```

can be rewritten as a first step to

```groovy
def object
try {
  sh 'mkdir -p $WORKSPACE_TMP  && something-yielding-secret-JSON > $WORKSPACE_TMP/secret.json'
  object = readJSON file: "$WORKSPACE_TMP/secret.json"
} finally {
  sh 'rm -f $WORKSPACE_TMP/secret.json'
}
```

but better still is to never have this secret JSON text pass through Pipeline script at all:

```groovy
sh 'something-yielding-secret-JSON | something-using-secret-JSON'
```

(Pipeline does not expect actual secrets to ever be exposed in plain text to Groovy code. `withCredentials` can be used to _inject_ secrets from Jenkins to a build, but if secrets are _produced_ within the build, there should be no reason for them to be loaded into orchestration logic itself.)