### PR TITLE
Set split lines for writeYaml to false

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStep.java
@@ -261,6 +261,7 @@ public class WriteYamlStep extends Step {
 
             DumperOptions options = new DumperOptions();
             options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+            options.setSplitLines(false);
             Yaml yaml = new Yaml(options);
 
             if (data == null) {
@@ -305,6 +306,7 @@ public class WriteYamlStep extends Step {
 
             DumperOptions options = new DumperOptions();
             options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+            options.setSplitLines(false);
             Yaml yaml = new Yaml(options);
 
             Charset cs;


### PR DESCRIPTION
Switch in [#149](https://github.com/jenkinsci/pipeline-utility-steps-plugin/pull/149) top use SnakeYAML API plugin also updated version of that plugin. And there was change in SplitLines from false to true. But this breaks up several functions for us. For example:
```
options:  "abc  sfksajfkl  jfajfkjakj  jqjlkkalkl  kajklfjalkd"
```
is then written to file in plugin version 2.13.0:
```
options:  "abc  sfksajfkl  jfajfkjakj  
      \ jqjlkkalkl  kajklfjalkd"
```
is then written to file in plugin version 2.12.2:
```
options:  "abc  sfksajfkl  jfajfkjakj jqjlkkalkl  kajklfjalkd"
```
This pull request fix utility pipeline to its previous behavior.
