### PR TITLE
fix help for ReadCSVStep

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/csv/ReadCSVStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/csv/ReadCSVStep/help.html
@@ -32,7 +32,7 @@ def records = readCSV file: 'dir/input.csv'
 assert records[0][0] == 'key'
 assert records[1][1] == 'b'
 
-def content = readCSV text: 'key,value\na,b'
+def records = readCSV text: 'key,value\na,b'
 assert records[0][0] == 'key'
 assert records[1][1] == 'b'
 	</pre></code>
@@ -45,8 +45,8 @@ def records = readCSV file: 'dir/input.csv', format: excelFormat
 assert records[0][0] == 'key'
 assert records[1][1] == 'b'
 
-def content = readCSV text: 'key,value\na,b', format: CSVFormat.DEFAULT.withHeader()
-assert records[1].get('key') == 'a'
-assert records[1].get('value') == 'b'
+def records = readCSV text: 'key,value\na,b', format: CSVFormat.DEFAULT.withHeader()
+assert records[0].get('key') == 'a'
+assert records[0].get('value') == 'b'
 	</pre></code>
 </p>


### PR DESCRIPTION
Trivial fix for the help.html on ReadCSVStep
* variable naming
* `.withHeader()` consumes the first record, so there is only one data record which has index `[0]`

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- ~Link to relevant issues in GitHub or Jira~
- ~Link to relevant pull requests, esp. upstream and downstream changes~
- ~Ensure you have provided tests - that demonstrates feature works or fixes the issue~

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
