### PR TITLE
Use library plugins where possible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,26 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-configuration2</artifactId>
             <version>2.8.0</version>
+            <exclusions>
+                <!-- Provided by commons-lang3-api plugin -->
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+                <!-- Provided by commons-text-api plugin -->
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-text</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-text-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-lang3-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Removes `WEB-INF/lib/commons-lang3-3.9.jar` and `WEB-INF/lib/commons-text-1.8.jar` from the JPI in favor of a plugin-to-plugin dependency of the corresponding library plugins, as is generally recommended for Jenkins plugins. Aside from slimming down the binary footprint of the JPI, this also resolves [JENKINS-69877](https://issues.jenkins.io/browse/JENKINS-69877) by implementing dynamic linking, allowing the [secure and updated] version of `commons-text` 1.10.0 to be pulled in from `commons-text-api` plugin rather than the oudated version currently bundled in `pipeline-utility-steps`.

CC @rsandell