### PR TITLE
use pinned version for commons-lang3-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>commons-lang3-api</artifactId>
+            <version>3.12.0-36.vd97de6465d5b_</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
It would be nice to use a pinned version for the dependency commons-lang3-api. My value is the latest version, as listed here: https://plugins.jenkins.io/commons-lang3-api/ 
Dependabot should be able to raise the version in the future. We are currently having problems with dependencies of other Jenkins plugins that use version 3.12.0-36.vd97de6465d5b_ of commons-lang3-api. This project is forcing 3.12.0.0.
Mainly because our company Jenkins has limited internet access.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
