### PR TITLE
[JENKINS-71077] Allow overriding codePointLimit to allow reading larger yaml files

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadYamlStep/help.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadYamlStep/help.groovy
@@ -58,6 +58,27 @@ ul {
         }
     }
     li {
+        code('codePointLimit: ')
+        text('Limit for incoming data in bytes. ')
+        text('Defaults to 3145728 (3MB) if not set.')
+        br()
+        em {
+            String max_code_point_limit_property = org.jenkinsci.plugins.pipeline.utility.steps.conf.ReadYamlStep.MAX_CODE_POINT_LIMIT_PROPERTY
+            String default_code_point_limit_property = org.jenkinsci.plugins.pipeline.utility.steps.conf.ReadYamlStep.DEFAULT_CODE_POINT_LIMIT_PROPERTY
+            int max_code_point_limit = org.jenkinsci.plugins.pipeline.utility.steps.conf.ReadYamlStep.getMaxCodePointLimit()
+            int default_code_point_limit = org.jenkinsci.plugins.pipeline.utility.steps.conf.ReadYamlStep.getDefaultCodePointLimit()
+            text("""\
+                There is a maximum value you can set on this controller: ${max_code_point_limit}.
+                The administrator can change the max allowed value by setting the System property: ${max_code_point_limit_property}.
+                The default can also be changed by setting the System property: ${default_code_point_limit_property}
+                so that no pipeline code needs to be changed. """.stripIndent())
+            if (default_code_point_limit >= -1) {
+                br()
+                text("On this controller the default is set to ${default_code_point_limit}.")
+            }
+        }
+    }
+    li {
         code('maxAliasesForCollections: ')
         text('Restrict the amount of aliases for collections (sequences and mappings) to avoid ')
         a(href:'https://en.wikipedia.org/wiki/Billion_laughs_attack') {


### PR DESCRIPTION
Since the upgrade to SnakeYAML 1.32 it is not possible to read YAML files greater than 3MB. This PR adds the new, optional  attribute `codePointLimit` to `readYaml`. This makes it possible to work around this limitation.


<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] ~~Link to relevant issues in GitHub or Jira~~
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

- https://bitbucket.org/snakeyaml/snakeyaml/issues/547/restrict-the-size-of-incoming-data
- https://bitbucket.org/snakeyaml/snakeyaml/commits/72dfa9f1074abe2b8a6c8776bee4476b0aed02e3
- https://bitbucket.org/snakeyaml/snakeyaml/commits/440d98e2ebd586aafd9034fc74a2a47c656eb0ce
