### PR TITLE
Forward compatibility with Guice 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <properties>
         <revision>2.16.1</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.361.4</jenkins.version>
+        <jenkins.version>2.414.3</jenkins.version>
         <spotbugs.effort>Max</spotbugs.effort>
         <spotbugs.failOnError>true</spotbugs.failOnError>
         <spotbugs.threshold>Medium</spotbugs.threshold>
@@ -159,8 +159,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.361.x</artifactId>
-                <version>2102.v854b_fec19c92</version>
+                <artifactId>bom-2.414.x</artifactId>
+                <version>2705.vf5c48c31285b_</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FindFilesStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FindFilesStepExecution.java
@@ -30,7 +30,7 @@ import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.util.Arrays;
 import java.util.List;
 


### PR DESCRIPTION
Without dropping compatibility with Guice 6 (currently delivered by Jenkins core), add support for Guice 7.