### PR TITLE
Add dependency on Commons Compress library plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,11 @@
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-compress-api</artifactId>
+            <version>1.26.1-1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
             <artifactId>commons-text-api</artifactId>
         </dependency>
         <dependency>
@@ -187,4 +192,28 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
+
+    <build>
+        <plugins>
+            <!-- TODO remove when Commons Compress is removed from core -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>display-info</id>
+                        <configuration>
+                            <rules>
+                                <requireUpperBoundDeps>
+                                    <excludes combine.children="append">
+                                        <exclude>org.apache.commons:commons-compress</exclude>
+                                    </excludes>
+                                </requireUpperBoundDeps>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
See [this thread](https://groups.google.com/g/jenkinsci-dev/c/dRY7NYuvLkM/m/8v65Z2MsAgAJ). Currently, this PR results in no change in behavior, since it adds a library plugin that will be unused at runtime, because core's copy will take precedence. But when Commons Compress is eventually removed from core, this linkage will allow this plugin to continue working. It will also allow us to update Commons Compress library plugin to recent versions, satisfying the Commons Lang 3 dependency via a plugin-to-plugin dependency between the Commons Compress library plugin and the Commons Lang 3 library plugin.

### Testing done

`mvn clean verify -Dtest=InjectedTest`