### PR TITLE
ReadYaml and WriteYaml steps support anchors and aliases without exploding them

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadYamlStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadYamlStep.java
@@ -300,3 +300,4 @@ public class ReadYamlStep extends AbstractFileOrTextStep {
 		}
 	}
 }
+

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStep.java
@@ -329,3 +329,4 @@ public class WriteYamlStep extends Step {
         }
     }
 }
+


### PR DESCRIPTION
As of now, ReadYaml and WriteYaml support anchors and aliases in the sense that they are parsed and processed correctly, but they are always exploded. Consider the following example.
You have an input file as follows:
```yaml
fruits: &fruit-anchor
  banana: 3
  apple: 5

packLunch:
  <<: *fruit-anchor
  pasta: 3
  cake: 2
```
and you want to read it, makes some changes, for instance adding `parmesan: 3` to the packedLunch:
```yaml
fruits: &fruit-anchor
  banana: 3
  apple: 5

packLunch:
  <<: *fruit-anchor
  pasta: 3
  parmesan: 3
  cake: 2
```
and write it back to the original file. The problem that we see is that the original file will have all anchors and aliases resolved (exploded), as follows, but we don't want that:
```yaml
fruits:
  banana: 3
  apple: 5

packLunch:
  banana: 3
  apple: 5
  pasta: 3
  parmesan: 3
  cake: 2
```

### Testing done

None done yet

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
