### PR TITLE
Migrate tests to JUnit5

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/FilenameTestsUtils.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/FilenameTestsUtils.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.plugins.pipeline.utility.steps;
 
 import java.io.File;
-
 import org.apache.commons.io.FilenameUtils;
 
 public final class FilenameTestsUtils {
@@ -21,12 +20,12 @@ public final class FilenameTestsUtils {
         if (path == null) {
             return null;
         }
-        String pathConverted=FilenameUtils.separatorsToSystem(path);
+        String pathConverted = FilenameUtils.separatorsToSystem(path);
         return pathConverted.replace("\\", "\\\\");
     }
 
     /**
-     * Convert a file to a platform agnostic representation.
+     * Convert a file to a platform-agnostic representation.
      *
      * @param file
      * @return a file path operative system aware

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepTest.java
@@ -24,123 +24,139 @@
 
 package org.jenkinsci.plugins.pipeline.utility.steps.conf;
 
-import hudson.model.Label;
-import hudson.model.Result;
-
 import static org.jenkinsci.plugins.pipeline.utility.steps.FilenameTestsUtils.separatorsToSystemEscaped;
 import static org.jenkinsci.plugins.pipeline.utility.steps.conf.ReadPropertiesStepExecution.CUSTOM_PREFIX_INTERPOLATOR_LOOKUPS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import org.jenkinsci.plugins.pipeline.utility.steps.Messages;
-import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
-import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.jvnet.hudson.test.FlagRule;
-import org.jvnet.hudson.test.Issue;
-import org.jvnet.hudson.test.JenkinsRule;
-
+import hudson.model.Label;
+import hudson.model.Result;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Properties;
+import org.jenkinsci.plugins.pipeline.utility.steps.Messages;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 /**
  * Tests for {@link ReadPropertiesStep}.
  *
  * @author Robert Sandell &lt;rsandell@cloudbees.com&gt;.
  */
-public class ReadPropertiesStepTest {
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
-    @Rule
-    public TemporaryFolder temp = new TemporaryFolder();
-    @Rule
-    public FlagRule<String> customLookups = new FlagRule<>(() -> CUSTOM_PREFIX_INTERPOLATOR_LOOKUPS, x -> CUSTOM_PREFIX_INTERPOLATOR_LOOKUPS = x);
+@WithJenkins
+class ReadPropertiesStepTest {
 
-    @Before
-    public void setup() throws Exception {
+    private JenkinsRule j;
+
+    @TempDir
+    private File temp;
+
+    private String customLookups;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) throws Exception {
+        j = rule;
         j.createOnlineSlave(Label.get("slaves"));
+        customLookups =
+                System.getProperty(ReadPropertiesStepExecution.class.getName() + ".CUSTOM_PREFIX_INTERPOLATOR_LOOKUPS");
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (customLookups != null) {
+            System.setProperty(
+                    ReadPropertiesStepExecution.class.getName() + ".CUSTOM_PREFIX_INTERPOLATOR_LOOKUPS", customLookups);
+        } else {
+            System.clearProperty(ReadPropertiesStepExecution.class.getName() + ".CUSTOM_PREFIX_INTERPOLATOR_LOOKUPS");
+        }
     }
 
     @Test
-    public void readFile() throws Exception {
+    void readFile() throws Exception {
         Properties props = new Properties();
         props.setProperty("test", "One");
         props.setProperty("another", "Two");
-        File file = temp.newFile();
+        File file = File.createTempFile("junit", null, temp);
         try (FileWriter f = new FileWriter(file)) {
             props.store(f, "Pipeline test");
         }
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  def props = readProperties file: '" + separatorsToSystemEscaped(file.getAbsolutePath()) + "'\n" +
-                        "  assert props['test'] == 'One'\n" +
-                        "  assert props['another'] == 'Two'\n" +
-                        "  assert props.test == 'One'\n" +
-                        "  assert props.another == 'Two'\n" +
-                        "}", true));
+                "node('slaves') {\n" + "  def props = readProperties file: '"
+                        + separatorsToSystemEscaped(file.getAbsolutePath()) + "'\n"
+                        + "  assert props['test'] == 'One'\n"
+                        + "  assert props['another'] == 'Two'\n"
+                        + "  assert props.test == 'One'\n"
+                        + "  assert props.another == 'Two'\n"
+                        + "}",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void readFileWithDefaults() throws Exception {
+    void readFileWithDefaults() throws Exception {
         Properties props = new Properties();
         props.setProperty("test", "One");
         props.setProperty("another", "Two");
-        File file = temp.newFile();
+        File file = File.createTempFile("junit", null, temp);
         try (FileWriter f = new FileWriter(file)) {
             props.store(f, "Pipeline test");
         }
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  def d = [test: 'Default', something: 'Default']\n" +
-                        "  def props = readProperties defaults: d, file: '" + separatorsToSystemEscaped(file.getAbsolutePath()) + "'\n" +
-                        "  assert props['test'] == 'One'\n" +
-                        "  assert props['another'] == 'Two'\n" +
-                        "  assert props.test == 'One'\n" +
-                        "  assert props.another == 'Two'\n" +
-                        "  assert props['something'] == 'Default'\n" +
-                        "  assert props.something == 'Default'\n" +
-                        "}", true));
+                "node('slaves') {\n" + "  def d = [test: 'Default', something: 'Default']\n"
+                        + "  def props = readProperties defaults: d, file: '"
+                        + separatorsToSystemEscaped(file.getAbsolutePath()) + "'\n"
+                        + "  assert props['test'] == 'One'\n"
+                        + "  assert props['another'] == 'Two'\n"
+                        + "  assert props.test == 'One'\n"
+                        + "  assert props.another == 'Two'\n"
+                        + "  assert props['something'] == 'Default'\n"
+                        + "  assert props.something == 'Default'\n"
+                        + "}",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void readFileWithCharset() throws Exception {
+    void readFileWithCharset() throws Exception {
         Properties props = new Properties();
         props.setProperty("test", "One");
         props.setProperty("another", "Two");
         props.setProperty("zh", "中文");
-        File file = temp.newFile();
+        File file = File.createTempFile("junit", null, temp);
         try (FileWriter f = new FileWriter(file, StandardCharsets.UTF_8)) {
             props.store(f, "Pipeline test");
         }
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  def props = readProperties charset: 'utf-8', file: '" + separatorsToSystemEscaped(file.getAbsolutePath()) + "'\n" +
-                        "  assert props['test'] == 'One'\n" +
-                        "  assert props['another'] == 'Two'\n" +
-                        "  assert props.test == 'One'\n" +
-                        "  assert props.another == 'Two'\n" +
-                        "  assert props.zh == '中文' \n" +
-                        "}", true));
+                "node('slaves') {\n" + "  def props = readProperties charset: 'utf-8', file: '"
+                        + separatorsToSystemEscaped(file.getAbsolutePath()) + "'\n"
+                        + "  assert props['test'] == 'One'\n"
+                        + "  assert props['another'] == 'Two'\n"
+                        + "  assert props.test == 'One'\n"
+                        + "  assert props.another == 'Two'\n"
+                        + "  assert props.zh == '中文' \n"
+                        + "}",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void readText() throws Exception {
+    void readText() throws Exception {
         Properties props = new Properties();
         props.setProperty("test", "One");
         props.setProperty("another", "Two");
@@ -149,44 +165,50 @@ public class ReadPropertiesStepTest {
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                        "def props = readProperties text: '''" + propsString + "'''\n" +
-                        "assert props['test'] == 'One'\n" +
-                        "assert props['another'] == 'Two'\n" +
-                        "assert props.test == 'One'\n" +
-                        "assert props.another == 'Two'\n", true));
+                "def props = readProperties text: '''" + propsString + "'''\n" + "assert props['test'] == 'One'\n"
+                        + "assert props['another'] == 'Two'\n"
+                        + "assert props.test == 'One'\n"
+                        + "assert props.another == 'Two'\n",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void readDirectText() throws Exception {
+    void readDirectText() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  def props = readProperties text: 'test=something'\n" +
-                        "  assert props['test'] == 'something'\n" +
-                        "  assert props.test == 'something'\n" +
-                        "  assert props.another == null\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          def props = readProperties text: 'test=something'
+                          assert props['test'] == 'something'
+                          assert props.test == 'something'
+                          assert props.another == null
+                        }""",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void readNone() throws Exception {
+    void readNone() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  def props = readProperties()\n" +
-                        "}", true));
-        WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
-        j.assertLogContains(Messages.AbstractFileOrTextStepDescriptorImpl_missingRequiredArgument("readProperties"), run);
+                """
+                        node('slaves') {
+                          def props = readProperties()
+                        }""",
+                true));
+        WorkflowRun run =
+                j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+        j.assertLogContains(
+                Messages.AbstractFileOrTextStepDescriptorImpl_missingRequiredArgument("readProperties"), run);
     }
 
     @Test
-    public void readFileAndText() throws Exception {
+    void readFileAndText() throws Exception {
         Properties props = new Properties();
         props.setProperty("test", "One");
         props.setProperty("another", "Two");
-        File file = temp.newFile();
+        File file = File.createTempFile("junit", null, temp);
         try (FileWriter f = new FileWriter(file)) {
             props.store(f, "Pipeline test");
         }
@@ -194,32 +216,34 @@ public class ReadPropertiesStepTest {
         props = new Properties();
         props.setProperty("text", "TextOne");
         props.setProperty("another", "TextTwo");
-        File textFile = temp.newFile();
+        File textFile = File.createTempFile("junit", null, temp);
         try (FileWriter f = new FileWriter(textFile)) {
             props.store(f, "Pipeline test");
         }
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  String propsText = readFile file: '" + separatorsToSystemEscaped(textFile.getAbsolutePath()) + "'\n" +
-                        "  def props = readProperties text: propsText, file: '" + separatorsToSystemEscaped(file.getAbsolutePath()) + "'\n" +
-                        "  assert props['test'] == 'One'\n" +
-                        "  assert props.test == 'One'\n" +
-                        "  assert props['text'] == 'TextOne'\n" +
-                        "  assert props.text == 'TextOne'\n" +
-                        "  assert props['another'] == 'TextTwo'\n" +
-                        "  assert props.another == 'TextTwo'\n" +
-                        "}", true));
+                "node('slaves') {\n" + "  String propsText = readFile file: '"
+                        + separatorsToSystemEscaped(textFile.getAbsolutePath()) + "'\n"
+                        + "  def props = readProperties text: propsText, file: '"
+                        + separatorsToSystemEscaped(file.getAbsolutePath()) + "'\n"
+                        + "  assert props['test'] == 'One'\n"
+                        + "  assert props.test == 'One'\n"
+                        + "  assert props['text'] == 'TextOne'\n"
+                        + "  assert props.text == 'TextOne'\n"
+                        + "  assert props['another'] == 'TextTwo'\n"
+                        + "  assert props.another == 'TextTwo'\n"
+                        + "}",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void readFileAndTextInterpolatedDisabled() throws Exception {
+    void readFileAndTextInterpolatedDisabled() throws Exception {
         Properties props = new Properties();
         props.setProperty("test", "One");
         props.setProperty("another", "Two");
-        File file = temp.newFile();
+        File file = File.createTempFile("junit", null, temp);
         try (FileWriter f = new FileWriter(file)) {
             props.store(f, "Pipeline test");
         }
@@ -228,50 +252,54 @@ public class ReadPropertiesStepTest {
         props.setProperty("url", "http://localhost");
         props.setProperty("file", "book.txt");
         props.setProperty("fileUrl", "${url}/${file}");
-        File textFile = temp.newFile();
+        File textFile = File.createTempFile("junit", null, temp);
         try (FileWriter f = new FileWriter(textFile)) {
             props.store(f, "Pipeline test");
         }
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  String propsText = readFile file: '" + separatorsToSystemEscaped(textFile.getAbsolutePath()) + "'\n" +
-                        "  def props = readProperties text: propsText, file: '" + separatorsToSystemEscaped(file.getAbsolutePath()) + "'\n" +
-                        "  assert props['test'] == 'One'\n" +
-                        "  assert props.test == 'One'\n" +
-                        "  assert props['url'] == 'http://localhost'\n" +
-                        "  assert props.url == 'http://localhost'\n" +
-                        "  assert props['file'] == 'book.txt'\n" +
-                        "  assert props.file == 'book.txt'\n" +
-                        "  assert props['fileUrl'] == '${url}/${file}'\n" +
-                        "  assert props.fileUrl == '${url}/${file}'\n" +
-                        "}", true));
+                "node('slaves') {\n" + "  String propsText = readFile file: '"
+                        + separatorsToSystemEscaped(textFile.getAbsolutePath()) + "'\n"
+                        + "  def props = readProperties text: propsText, file: '"
+                        + separatorsToSystemEscaped(file.getAbsolutePath()) + "'\n"
+                        + "  assert props['test'] == 'One'\n"
+                        + "  assert props.test == 'One'\n"
+                        + "  assert props['url'] == 'http://localhost'\n"
+                        + "  assert props.url == 'http://localhost'\n"
+                        + "  assert props['file'] == 'book.txt'\n"
+                        + "  assert props.file == 'book.txt'\n"
+                        + "  assert props['fileUrl'] == '${url}/${file}'\n"
+                        + "  assert props.fileUrl == '${url}/${file}'\n"
+                        + "}",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
 
         p = j.jenkins.createProject(WorkflowJob.class, "p2");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  String propsText = readFile file: '" + separatorsToSystemEscaped(textFile.getAbsolutePath()) + "'\n" +
-                        "  def props = readProperties interpolate: false, text: propsText, file: '" + separatorsToSystemEscaped(file.getAbsolutePath()) + "'\n" +
-                        "  assert props['test'] == 'One'\n" +
-                        "  assert props.test == 'One'\n" +
-                        "  assert props['url'] == 'http://localhost'\n" +
-                        "  assert props.url == 'http://localhost'\n" +
-                        "  assert props['file'] == 'book.txt'\n" +
-                        "  assert props.file == 'book.txt'\n" +
-                        "  assert props['fileUrl'] == '${url}/${file}'\n" +
-                        "  assert props.fileUrl == '${url}/${file}'\n" +
-                        "}", true));
+                "node('slaves') {\n" + "  String propsText = readFile file: '"
+                        + separatorsToSystemEscaped(textFile.getAbsolutePath()) + "'\n"
+                        + "  def props = readProperties interpolate: false, text: propsText, file: '"
+                        + separatorsToSystemEscaped(file.getAbsolutePath()) + "'\n"
+                        + "  assert props['test'] == 'One'\n"
+                        + "  assert props.test == 'One'\n"
+                        + "  assert props['url'] == 'http://localhost'\n"
+                        + "  assert props.url == 'http://localhost'\n"
+                        + "  assert props['file'] == 'book.txt'\n"
+                        + "  assert props.file == 'book.txt'\n"
+                        + "  assert props['fileUrl'] == '${url}/${file}'\n"
+                        + "  assert props.fileUrl == '${url}/${file}'\n"
+                        + "}",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void readFileAndTextInterpolated() throws Exception {
+    void readFileAndTextInterpolated() throws Exception {
         Properties props = new Properties();
         props.setProperty("test", "One");
         props.setProperty("another", "Two");
-        File file = temp.newFile();
+        File file = File.createTempFile("junit", null, temp);
         try (FileWriter f = new FileWriter(file)) {
             props.store(f, "Pipeline test");
         }
@@ -280,34 +308,36 @@ public class ReadPropertiesStepTest {
         props.setProperty("url", "http://localhost");
         props.setProperty("file", "book.txt");
         props.setProperty("fileUrl", "${url}/${file}");
-        File textFile = temp.newFile();
+        File textFile = File.createTempFile("junit", null, temp);
         try (FileWriter f = new FileWriter(textFile)) {
             props.store(f, "Pipeline test");
         }
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  String propsText = readFile file: '" + separatorsToSystemEscaped(textFile.getAbsolutePath()) + "'\n" +
-                        "  def props = readProperties interpolate: true, text: propsText, file: '" + separatorsToSystemEscaped(file.getAbsolutePath()) + "'\n" +
-                        "  assert props['test'] == 'One'\n" +
-                        "  assert props.test == 'One'\n" +
-                        "  assert props['url'] == 'http://localhost'\n" +
-                        "  assert props.url == 'http://localhost'\n" +
-                        "  assert props['file'] == 'book.txt'\n" +
-                        "  assert props.file == 'book.txt'\n" +
-                        "  assert props['fileUrl'] == 'http://localhost/book.txt'\n" +
-                        "  assert props.fileUrl == 'http://localhost/book.txt'\n" +
-                        "}", true));
+                "node('slaves') {\n" + "  String propsText = readFile file: '"
+                        + separatorsToSystemEscaped(textFile.getAbsolutePath()) + "'\n"
+                        + "  def props = readProperties interpolate: true, text: propsText, file: '"
+                        + separatorsToSystemEscaped(file.getAbsolutePath()) + "'\n"
+                        + "  assert props['test'] == 'One'\n"
+                        + "  assert props.test == 'One'\n"
+                        + "  assert props['url'] == 'http://localhost'\n"
+                        + "  assert props.url == 'http://localhost'\n"
+                        + "  assert props['file'] == 'book.txt'\n"
+                        + "  assert props.file == 'book.txt'\n"
+                        + "  assert props['fileUrl'] == 'http://localhost/book.txt'\n"
+                        + "  assert props.fileUrl == 'http://localhost/book.txt'\n"
+                        + "}",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
-    
+
     @Test
-    public void readFileAndTextAndDefaultsInterpolated() throws Exception {
+    void readFileAndTextAndDefaultsInterpolated() throws Exception {
         Properties props = new Properties();
         props.setProperty("test", "One");
         props.setProperty("another", "Two");
-        File file = temp.newFile();
+        File file = File.createTempFile("junit", null, temp);
         try (FileWriter f = new FileWriter(file)) {
             props.store(f, "Pipeline test");
         }
@@ -315,35 +345,37 @@ public class ReadPropertiesStepTest {
         props = new Properties();
         props.setProperty("file", "book.txt");
         props.setProperty("fileUrl", "${url}/${file}");
-        File textFile = temp.newFile();
+        File textFile = File.createTempFile("junit", null, temp);
         try (FileWriter f = new FileWriter(textFile)) {
             props.store(f, "Pipeline test");
         }
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  String propsText = readFile file: '" + separatorsToSystemEscaped(textFile.getAbsolutePath()) + "'\n" +
-                		"  def defaults = [\"url\": \"http://localhost\"]\n" + 
-                        "  def props = readProperties interpolate: true, defaults: defaults, text: propsText, file: '" + separatorsToSystemEscaped(file.getAbsolutePath()) + "'\n" +
-                        "  assert props['test'] == 'One'\n" +
-                        "  assert props.test == 'One'\n" +
-                        "  assert props['url'] == 'http://localhost'\n" +
-                        "  assert props.url == 'http://localhost'\n" +
-                        "  assert props['file'] == 'book.txt'\n" +
-                        "  assert props.file == 'book.txt'\n" +
-                        "  assert props['fileUrl'] == 'http://localhost/book.txt'\n" +
-                        "  assert props.fileUrl == 'http://localhost/book.txt'\n" +
-                        "}", true));
+                "node('slaves') {\n" + "  String propsText = readFile file: '"
+                        + separatorsToSystemEscaped(textFile.getAbsolutePath()) + "'\n"
+                        + "  def defaults = [\"url\": \"http://localhost\"]\n"
+                        + "  def props = readProperties interpolate: true, defaults: defaults, text: propsText, file: '"
+                        + separatorsToSystemEscaped(file.getAbsolutePath()) + "'\n"
+                        + "  assert props['test'] == 'One'\n"
+                        + "  assert props.test == 'One'\n"
+                        + "  assert props['url'] == 'http://localhost'\n"
+                        + "  assert props.url == 'http://localhost'\n"
+                        + "  assert props['file'] == 'book.txt'\n"
+                        + "  assert props.file == 'book.txt'\n"
+                        + "  assert props['fileUrl'] == 'http://localhost/book.txt'\n"
+                        + "  assert props.fileUrl == 'http://localhost/book.txt'\n"
+                        + "}",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void readFileAndTextInterpolatedWithCyclicValues() throws Exception {
+    void readFileAndTextInterpolatedWithCyclicValues() throws Exception {
         Properties props = new Properties();
         props.setProperty("test", "One");
         props.setProperty("another", "Two");
-        File file = temp.newFile();
+        File file = File.createTempFile("junit", null, temp);
         try (FileWriter f = new FileWriter(file)) {
             props.store(f, "Pipeline test");
         }
@@ -352,95 +384,100 @@ public class ReadPropertiesStepTest {
         props.setProperty("url", "${file}");
         props.setProperty("file", "${fileUrl}");
         props.setProperty("fileUrl", "${url}");
-        File textFile = temp.newFile();
+        File textFile = File.createTempFile("junit", null, temp);
         try (FileWriter f = new FileWriter(textFile)) {
             props.store(f, "Pipeline test");
         }
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  String propsText = readFile file: '" + separatorsToSystemEscaped(textFile.getAbsolutePath()) + "'\n" +
-                        "  def props = readProperties text: propsText, interpolate: true, file: '" + separatorsToSystemEscaped(file.getAbsolutePath()) + "'\n" +
-                        "  assert props['test'] == 'One'\n" +
-                        "  assert props.test == 'One'\n" +
-                        "  assert props['url'] == '${file}'\n" +
-                        "  assert props.url == '${file}'\n" +
-                        "  assert props['file'] == '${fileUrl}'\n" +
-                        "  assert props.file == '${fileUrl}'\n" +
-                        "  assert props['fileUrl'] == '${url}'\n" +
-                        "  assert props.fileUrl == '${url}'\n" +
-                        "}", true));
+                "node('slaves') {\n" + "  String propsText = readFile file: '"
+                        + separatorsToSystemEscaped(textFile.getAbsolutePath()) + "'\n"
+                        + "  def props = readProperties text: propsText, interpolate: true, file: '"
+                        + separatorsToSystemEscaped(file.getAbsolutePath()) + "'\n"
+                        + "  assert props['test'] == 'One'\n"
+                        + "  assert props.test == 'One'\n"
+                        + "  assert props['url'] == '${file}'\n"
+                        + "  assert props.url == '${file}'\n"
+                        + "  assert props['file'] == '${fileUrl}'\n"
+                        + "  assert props.file == '${fileUrl}'\n"
+                        + "  assert props['fileUrl'] == '${url}'\n"
+                        + "  assert props.fileUrl == '${url}'\n"
+                        + "}",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Issue("SECURITY-2949")
     @Test
-    public void unsafeInterpolatorsDoNotInterpolate() throws Exception {
+    void unsafeInterpolatorsDoNotInterpolate() throws Exception {
         Properties props = new Properties();
         props.setProperty("file", "${file:utf8:/etc/passwd}");
         props.setProperty("hax", "${script:Groovy:jenkins.model.Jenkins.get().systemMessage = 'pwn3d'}");
-        File textFile = temp.newFile();
+        File textFile = File.createTempFile("junit", null, temp);
         try (FileWriter f = new FileWriter(textFile)) {
             props.store(f, "Pipeline test");
         }
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  def props = readProperties interpolate: true, file: '" + separatorsToSystemEscaped(textFile.getAbsolutePath()) + "'\n" +
-                        "  assert props['file'] == '${file:utf8:/etc/passwd}'\n" +
-                        "  assert props['hax'] == '${script:Groovy:jenkins.model.Jenkins.get().systemMessage = \\'pwn3d\\'}'\n" +
-                        "}", true));
+                "node('slaves') {\n" + "  def props = readProperties interpolate: true, file: '"
+                        + separatorsToSystemEscaped(textFile.getAbsolutePath()) + "'\n"
+                        + "  assert props['file'] == '${file:utf8:/etc/passwd}'\n"
+                        + "  assert props['hax'] == '${script:Groovy:jenkins.model.Jenkins.get().systemMessage = \\'pwn3d\\'}'\n"
+                        + "}",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         assertNotEquals("pwn3d", j.jenkins.getSystemMessage());
     }
 
     @Issue("SECURITY-2949")
     @Test
-    public void safeInterpolatorsDoInterpolate() throws Exception {
+    void safeInterpolatorsDoInterpolate() throws Exception {
         Properties props = new Properties();
         props.setProperty("urld", "${urlDecoder:Hello+World%21}");
         props.setProperty("urle", "${urlEncoder:Hello World!}");
         props.setProperty("base64d", "${base64Decoder:SGVsbG9Xb3JsZCE=}");
         props.setProperty("base64e", "${base64Encoder:HelloWorld!}");
-        File textFile = temp.newFile();
+        File textFile = File.createTempFile("junit", null, temp);
         try (FileWriter f = new FileWriter(textFile)) {
             props.store(f, "Pipeline test");
         }
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  def props = readProperties interpolate: true, file: '" + separatorsToSystemEscaped(textFile.getAbsolutePath()) + "'\n" +
-                        "  assert props['base64d'] == 'HelloWorld!'\n" +
-                        "  assert props['base64e'] == 'SGVsbG9Xb3JsZCE='\n" +
-                        "  assert props['urld'] == 'Hello World!'\n" +
-                        "  assert props['urle'] == 'Hello+World%21'\n" +
-                        "}", true));
+                "node('slaves') {\n" + "  def props = readProperties interpolate: true, file: '"
+                        + separatorsToSystemEscaped(textFile.getAbsolutePath()) + "'\n"
+                        + "  assert props['base64d'] == 'HelloWorld!'\n"
+                        + "  assert props['base64e'] == 'SGVsbG9Xb3JsZCE='\n"
+                        + "  assert props['urld'] == 'Hello World!'\n"
+                        + "  assert props['urle'] == 'Hello+World%21'\n"
+                        + "}",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Issue("SECURITY-2949")
     @Test
-    public void customLookupsOverrideDefaultInterpolators() throws Exception {
+    void customLookupsOverrideDefaultInterpolators() throws Exception {
         CUSTOM_PREFIX_INTERPOLATOR_LOOKUPS = "script,base64_encoder";
 
         Properties props = new Properties();
         props.setProperty("hax", "${script:Groovy:jenkins.model.Jenkins.get().systemMessage = 'pwn3d'}");
         props.setProperty("base64d", "${base64Decoder:SGVsbG9Xb3JsZCE=}");
         props.setProperty("base64e", "${base64Encoder:HelloWorld!}");
-        File textFile = temp.newFile();
+        File textFile = File.createTempFile("junit", null, temp);
         try (FileWriter f = new FileWriter(textFile)) {
             props.store(f, "Pipeline test");
         }
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  def props = readProperties interpolate: true, file: '" + separatorsToSystemEscaped(textFile.getAbsolutePath()) + "'\n" +
-                        "  assert props['base64d'] == '${base64Decoder:SGVsbG9Xb3JsZCE=}'\n" +
-                        "  assert props['base64e'] == 'SGVsbG9Xb3JsZCE='\n" +
-                        "}", true));
+                "node('slaves') {\n" + "  def props = readProperties interpolate: true, file: '"
+                        + separatorsToSystemEscaped(textFile.getAbsolutePath()) + "'\n"
+                        + "  assert props['base64d'] == '${base64Decoder:SGVsbG9Xb3JsZCE=}'\n"
+                        + "  assert props['base64e'] == 'SGVsbG9Xb3JsZCE='\n"
+                        + "}",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         assertEquals("pwn3d", j.jenkins.getSystemMessage());
     }

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadYamlStepSystemPropertiesTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadYamlStepSystemPropertiesTest.java
@@ -1,26 +1,49 @@
 package org.jenkinsci.plugins.pipeline.utility.steps.conf;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.jvnet.hudson.test.FlagRule;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-import static org.junit.Assert.assertEquals;
+@WithJenkins
+class ReadYamlStepSystemPropertiesTest {
 
-public class ReadYamlStepSystemPropertiesTest {
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+    private final int testValue = 51;
 
-    private final int testValue=51;
+    private String defaultAliases;
 
-    @Rule
-    public final FlagRule<String> defaultAliases=FlagRule.systemProperty("org.jenkinsci.plugins.pipeline.utility.steps.conf.ReadYamlStep.DEFAULT_MAX_ALIASES_FOR_COLLECTIONS", String.valueOf(testValue));
+    private String maxAliases;
 
-    @Rule
-    public final FlagRule<String> maxAliases=FlagRule.systemProperty("org.jenkinsci.plugins.pipeline.utility.steps.conf.ReadYamlStep.MAX_MAX_ALIASES_FOR_COLLECTIONS", String.valueOf(testValue));
+    private JenkinsRule j;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) {
+        j = rule;
+        defaultAliases = System.setProperty(
+                ReadYamlStep.class.getName() + ".DEFAULT_MAX_ALIASES_FOR_COLLECTIONS", String.valueOf(testValue));
+        maxAliases = System.setProperty(
+                ReadYamlStep.class.getName() + ".MAX_MAX_ALIASES_FOR_COLLECTIONS", String.valueOf(testValue));
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (defaultAliases != null) {
+            System.setProperty(ReadYamlStep.class.getName() + ".DEFAULT_MAX_ALIASES_FOR_COLLECTIONS", defaultAliases);
+        } else {
+            System.clearProperty(ReadYamlStep.class.getName() + ".DEFAULT_MAX_ALIASES_FOR_COLLECTIONS");
+        }
+        if (maxAliases != null) {
+            System.setProperty(ReadYamlStep.class.getName() + ".MAX_MAX_ALIASES_FOR_COLLECTIONS", maxAliases);
+        } else {
+            System.clearProperty(ReadYamlStep.class.getName() + ".MAX_MAX_ALIASES_FOR_COLLECTIONS");
+        }
+    }
 
     @Test
-    public void testSettingYamlAliasesSetAtStartup() throws Exception {
+    void testSettingYamlAliasesSetAtStartup() {
         ReadYamlStep readYamlStep = new ReadYamlStep();
         assertEquals(testValue, readYamlStep.getDefaultMaxAliasesForCollections());
         assertEquals(testValue, readYamlStep.getMaxMaxAliasesForCollections());

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadYamlStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadYamlStepTest.java
@@ -1,284 +1,316 @@
 package org.jenkinsci.plugins.pipeline.utility.steps.conf;
 
+import static org.jenkinsci.plugins.pipeline.utility.steps.FilenameTestsUtils.separatorsToSystemEscaped;
+import static org.junit.jupiter.api.Assertions.*;
+
+import hudson.model.Label;
+import hudson.model.Result;
 import java.io.File;
 import java.nio.charset.Charset;
-
 import org.apache.commons.io.FileUtils;
-import static org.jenkinsci.plugins.pipeline.utility.steps.FilenameTestsUtils.separatorsToSystemEscaped;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-
 import org.jenkinsci.plugins.pipeline.utility.steps.Messages;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import hudson.model.Label;
-import hudson.model.Result;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.yaml.snakeyaml.LoaderOptions;
 
-public class ReadYamlStepTest {
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
-    @Rule
-    public TemporaryFolder temp = new TemporaryFolder();
+@WithJenkins
+class ReadYamlStepTest {
 
-    private final String yamlText="boolean: true\n"
-    		+ "string: 'string'\n"
-    		+ "integer: 3\n"
-    		+ "double: 3.14\n"
-    		+ "null: null\n"
-    		+ "date: 2001-12-14T21:59:43.10Z\n"
-    		+ "billTo:\n"
-    		+ " address:\n"
-    		+ "  postal  : 48046\n"
-    		+ "array:\n"
-			+ " - value1\n"
-			+ " - value2";
-    
-    private final String yamlTextOverride="boolean: false\n"
-    		+ "integer: 0\n";
-    
-    private final String yamlSeveralDocuments=
-    		"---\n"
-    		+ "string: 'doc1'\n"
-    		+ "---\n"
-    		+ "string: 'doc2'\n"
-    		+ "...\n"
-    		+ "---\n"
-    		+ "string: 'doc3'\n";
-    
-    @Before
-    public void setup() throws Exception {
-        System.setProperty("org.jenkinsci.plugins.pipeline.utility.steps.conf.ReadYamlStep.MAX_CODE_POINT_LIMIT", "10485760");
-        System.setProperty("org.jenkinsci.plugins.pipeline.utility.steps.conf.ReadYamlStep.MAX_MAX_ALIASES_FOR_COLLECTIONS", "500");
+    private JenkinsRule j;
+
+    @TempDir
+    private File temp;
+
+    private final String yamlText =
+            """
+            boolean: true
+            string: 'string'
+            integer: 3
+            double: 3.14
+            null: null
+            date: 2001-12-14T21:59:43.10Z
+            billTo:
+             address:
+              postal  : 48046
+            array:
+             - value1
+             - value2""";
+
+    private final String yamlTextOverride = """
+            boolean: false
+            integer: 0
+            """;
+
+    private final String yamlSeveralDocuments =
+            """
+                    ---
+                    string: 'doc1'
+                    ---
+                    string: 'doc2'
+                    ...
+                    ---
+                    string: 'doc3'
+                    """;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) throws Exception {
+        j = rule;
+        System.setProperty(
+                "org.jenkinsci.plugins.pipeline.utility.steps.conf.ReadYamlStep.MAX_CODE_POINT_LIMIT", "10485760");
+        System.setProperty(
+                "org.jenkinsci.plugins.pipeline.utility.steps.conf.ReadYamlStep.MAX_MAX_ALIASES_FOR_COLLECTIONS",
+                "500");
         j.createOnlineSlave(Label.get("slaves"));
     }
 
     @Test
-    public void checksPrimitivesAndDates() throws Exception {
-		WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-		p.setDefinition(new CpsFlowDefinition(
-				"node('slaves') {\n" + "  def yaml = readYaml text: '''" + yamlText + "'''\n" 
-						+ "  assert yaml.getClass().getName() == 'java.util.LinkedHashMap'\n" +
-						"  assert yaml.boolean.getClass().getName() == 'java.lang.Boolean'\n" +
-						"  assert yaml.string.getClass().getName() == 'java.lang.String'\n" +
-						"  assert yaml.integer.getClass().getName() == 'java.lang.Integer'\n" +
-						"  assert yaml.double.getClass().getName() == 'java.lang.Double'\n" +
-						"  def timeZone = TimeZone.getTimeZone('UTC')\n" +
-						"  assert yaml.date.format('yyyy-MM-dd HH:mm:ss',timeZone) == '2001-12-14 21:59:43'\n" +
-						"  assert yaml.date.getClass().getName() == 'java.util.Date'\n" +
-						"  assert yaml.billTo.getClass().getName() == 'java.util.LinkedHashMap'\n" +
-						"  assert yaml.billTo.address.getClass().getName() == 'java.util.LinkedHashMap'\n" +
-						"  assert yaml.billTo.address.postal.getClass().getName() == 'java.lang.Integer'\n" +
-						"  assert yaml.array.getClass().getName() == 'java.util.ArrayList'\n" +
-				        "  assert yaml.array[0].getClass().getName() == 'java.lang.String'\n" +
-						"  assert yaml.array[1].getClass().getName() == 'java.lang.String'\n" +
-				        "}",
-				true));
-		j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    void checksPrimitivesAndDates() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node('slaves') {\n" + "  def yaml = readYaml text: '''" + yamlText + "'''\n"
+                        + "  assert yaml.getClass().getName() == 'java.util.LinkedHashMap'\n"
+                        + "  assert yaml.boolean.getClass().getName() == 'java.lang.Boolean'\n"
+                        + "  assert yaml.string.getClass().getName() == 'java.lang.String'\n"
+                        + "  assert yaml.integer.getClass().getName() == 'java.lang.Integer'\n"
+                        + "  assert yaml.double.getClass().getName() == 'java.lang.Double'\n"
+                        + "  def timeZone = TimeZone.getTimeZone('UTC')\n"
+                        + "  assert yaml.date.format('yyyy-MM-dd HH:mm:ss',timeZone) == '2001-12-14 21:59:43'\n"
+                        + "  assert yaml.date.getClass().getName() == 'java.util.Date'\n"
+                        + "  assert yaml.billTo.getClass().getName() == 'java.util.LinkedHashMap'\n"
+                        + "  assert yaml.billTo.address.getClass().getName() == 'java.util.LinkedHashMap'\n"
+                        + "  assert yaml.billTo.address.postal.getClass().getName() == 'java.lang.Integer'\n"
+                        + "  assert yaml.array.getClass().getName() == 'java.util.ArrayList'\n"
+                        + "  assert yaml.array[0].getClass().getName() == 'java.lang.String'\n"
+                        + "  assert yaml.array[1].getClass().getName() == 'java.lang.String'\n"
+                        + "}",
+                true));
+        j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void readDirectText() throws Exception {
-		WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-		p.setDefinition(new CpsFlowDefinition(
-				"node('slaves') {\n" + "  def yaml = readYaml text: '''" + yamlText + "'''\n" 
-						+ "  assert yaml.boolean == true\n" +
-						"  assert yaml.string == 'string'\n" +
-						"  assert yaml.integer == 3\n" +
-						"  assert yaml.double == 3.14\n" +
-						"  assert yaml.null == null\n" +
-						"  assert yaml.billTo.address.postal == 48046\n" +
-						"  assert yaml.array.size() == 2\n" +
-						"  assert yaml.array[0] == 'value1'\n" +
-						"  assert yaml.array[1] == 'value2'\n" +
-				        "  assert yaml.another == null\n" + "}",
-				true));
-		j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    void readDirectText() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node('slaves') {\n" + "  def yaml = readYaml text: '''" + yamlText + "'''\n"
+                        + "  assert yaml.boolean == true\n" + "  assert yaml.string == 'string'\n"
+                        + "  assert yaml.integer == 3\n"
+                        + "  assert yaml.double == 3.14\n"
+                        + "  assert yaml.null == null\n"
+                        + "  assert yaml.billTo.address.postal == 48046\n"
+                        + "  assert yaml.array.size() == 2\n"
+                        + "  assert yaml.array[0] == 'value1'\n"
+                        + "  assert yaml.array[1] == 'value2'\n"
+                        + "  assert yaml.another == null\n"
+                        + "}",
+                true));
+        j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
-    
+
     @Test
-    public void readSeveralDocuments() throws Exception {
-		WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-		p.setDefinition(new CpsFlowDefinition("node('slaves') {\n"+
-			"  def yaml = readYaml text: '''"+yamlSeveralDocuments+"'''\n" +
-			"  assert yaml.size() == 3\n" +
-			"  assert yaml[0].string == 'doc1'\n" +
-			"  assert yaml[1].string == 'doc2'\n" +
-			"  assert yaml[2].string == 'doc3'\n" +
-	        "}", true));
-		j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    void readSeveralDocuments() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node('slaves') {\n" + "  def yaml = readYaml text: '''"
+                        + yamlSeveralDocuments + "'''\n" + "  assert yaml.size() == 3\n"
+                        + "  assert yaml[0].string == 'doc1'\n"
+                        + "  assert yaml[1].string == 'doc2'\n"
+                        + "  assert yaml[2].string == 'doc3'\n"
+                        + "}",
+                true));
+        j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
-    
+
     @Test
-    public void readText() throws Exception {
-		WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-		p.setDefinition(new CpsFlowDefinition(
-				"def yaml = readYaml text: '''" + yamlText + "'''\n" +
-						"assert yaml.boolean == true\n" +
-						"assert yaml.string == 'string'\n" +
-						"assert yaml.integer == 3\n" +
-						"assert yaml.double == 3.14\n" +
-						"assert yaml.null == null\n" +
-						"assert yaml.billTo.address.postal == 48046\n" +
-						"assert yaml.array.size() == 2\n" +
-						"assert yaml.array[0] == 'value1'\n" +
-						"assert yaml.array[1] == 'value2'\n" +
-						"assert yaml.another == null\n",
-				true));
-		WorkflowRun run = p.scheduleBuild2(0).get();
+    void readText() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "def yaml = readYaml text: '''" + yamlText + "'''\n" + "assert yaml.boolean == true\n"
+                        + "assert yaml.string == 'string'\n"
+                        + "assert yaml.integer == 3\n"
+                        + "assert yaml.double == 3.14\n"
+                        + "assert yaml.null == null\n"
+                        + "assert yaml.billTo.address.postal == 48046\n"
+                        + "assert yaml.array.size() == 2\n"
+                        + "assert yaml.array[0] == 'value1'\n"
+                        + "assert yaml.array[1] == 'value2'\n"
+                        + "assert yaml.another == null\n",
+                true));
+        WorkflowRun run = p.scheduleBuild2(0).get();
         System.out.println(JenkinsRule.getLog(run));
         j.assertBuildStatusSuccess(run);
     }
-    
+
     @Test
-    public void readFile() throws Exception {
-       
-    	File file = temp.newFile();
-    	FileUtils.writeStringToFile(file, yamlText, Charset.defaultCharset());
+    void readFile() throws Exception {
+
+        File file = File.createTempFile("junit", null, temp);
+        FileUtils.writeStringToFile(file, yamlText, Charset.defaultCharset());
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  def yaml = readYaml file: '" + separatorsToSystemEscaped(file.getAbsolutePath()) + "'\n" +
-            			"  assert yaml.boolean == true\n" +
-            			"  assert yaml.string == 'string'\n" +
-            			"  assert yaml.integer == 3\n" +
-            			"  assert yaml.double == 3.14\n" +
-            			"  assert yaml.null == null\n" +
-            			"  assert yaml.billTo.address.postal == 48046\n" +
-            			"  assert yaml.array.size() == 2\n" +
-            			"  assert yaml.array[0] == 'value1'\n" +
-            			"  assert yaml.array[1] == 'value2'\n" +
-            	        "  assert yaml.another == null\n" + "}",
-            	        true));
+                "node('slaves') {\n" + "  def yaml = readYaml file: '"
+                        + separatorsToSystemEscaped(file.getAbsolutePath()) + "'\n" + "  assert yaml.boolean == true\n"
+                        + "  assert yaml.string == 'string'\n"
+                        + "  assert yaml.integer == 3\n"
+                        + "  assert yaml.double == 3.14\n"
+                        + "  assert yaml.null == null\n"
+                        + "  assert yaml.billTo.address.postal == 48046\n"
+                        + "  assert yaml.array.size() == 2\n"
+                        + "  assert yaml.array[0] == 'value1'\n"
+                        + "  assert yaml.array[1] == 'value2'\n"
+                        + "  assert yaml.another == null\n"
+                        + "}",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
-    
+
     @Test
-    public void readFileAndText() throws Exception {
-        File file = temp.newFile();
+    void readFileAndText() throws Exception {
+        File file = File.createTempFile("junit", null, temp);
         FileUtils.writeStringToFile(file, yamlText, Charset.defaultCharset());
 
-        File fileOverride = temp.newFile();
+        File fileOverride = File.createTempFile("junit", null, temp);
         FileUtils.writeStringToFile(fileOverride, yamlTextOverride, Charset.defaultCharset());
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                		"  String yamlText = readFile file: '" + separatorsToSystemEscaped(fileOverride.getAbsolutePath()) + "'\n" +
-                        "  def yaml = readYaml text: yamlText, file: '" + separatorsToSystemEscaped(file.getAbsolutePath()) + "'\n" +
-            			"  assert yaml.boolean == false\n" +
-            			"  assert yaml.string == 'string'\n" +
-            			"  assert yaml.integer == 0\n" +
-            			"  assert yaml.double == 3.14\n" +
-            			"  assert yaml.null == null\n" +
-            			"  assert yaml.billTo.address.postal == 48046\n" +
-            			"  assert yaml.array.size() == 2\n" +
-            			"  assert yaml.array[0] == 'value1'\n" +
-            			"  assert yaml.array[1] == 'value2'\n" +
-            	        "  assert yaml.another == null\n" + "}",
-            	        true));
+                "node('slaves') {\n" + "  String yamlText = readFile file: '"
+                        + separatorsToSystemEscaped(fileOverride.getAbsolutePath()) + "'\n"
+                        + "  def yaml = readYaml text: yamlText, file: '"
+                        + separatorsToSystemEscaped(file.getAbsolutePath()) + "'\n" + "  assert yaml.boolean == false\n"
+                        + "  assert yaml.string == 'string'\n"
+                        + "  assert yaml.integer == 0\n"
+                        + "  assert yaml.double == 3.14\n"
+                        + "  assert yaml.null == null\n"
+                        + "  assert yaml.billTo.address.postal == 48046\n"
+                        + "  assert yaml.array.size() == 2\n"
+                        + "  assert yaml.array[0] == 'value1'\n"
+                        + "  assert yaml.array[1] == 'value2'\n"
+                        + "  assert yaml.another == null\n"
+                        + "}",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
+    @Test
+    void codePointLimits() throws Exception {
+        StringBuilder str = new StringBuilder("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        int desired = new LoaderOptions().getCodePointLimit();
+        while (str.length() < desired) {
+            str.append(str);
+        }
+        final String yaml = "a: " + str;
+        File file = File.createTempFile("junit", null, temp);
+        FileUtils.writeStringToFile(file, yaml, Charset.defaultCharset());
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node('" + j.jenkins.getSelfLabel() + "') { def yaml = readYaml file: '"
+                        + separatorsToSystemEscaped(file.getAbsolutePath()) + "'}",
+                true));
+        j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
+        p.setDefinition(new CpsFlowDefinition(
+                "node('" + j.jenkins.getSelfLabel() + "') { def yaml = readYaml codePointLimit: 10485760, file: '"
+                        + separatorsToSystemEscaped(file.getAbsolutePath()) + "'}",
+                true));
+        j.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0));
+    }
 
-	@Test
-	public void codePointLimits() throws Exception {
-		StringBuilder str = new StringBuilder("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-		int desired = new LoaderOptions().getCodePointLimit();
-		while (str.length() < desired) {
-			str.append(str);
-		}
-		final String yaml = "a: " + str;
-		File file = temp.newFile();
-		FileUtils.writeStringToFile(file, yaml, Charset.defaultCharset());
-		WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-		p.setDefinition(new CpsFlowDefinition(
-				"node('"+j.jenkins.getSelfLabel()+"') { def yaml = readYaml file: '" + separatorsToSystemEscaped(file.getAbsolutePath()) + "'}",
-				true));
-		j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
-		p.setDefinition(new CpsFlowDefinition(
-				"node('"+j.jenkins.getSelfLabel()+"') { def yaml = readYaml codePointLimit: 10485760, file: '" + separatorsToSystemEscaped(file.getAbsolutePath()) + "'}",
-				true));
-		j.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0));
-	}
+    @Test
+    void setDefaultCodePointLimitHigherThanMaxFailsWithException() {
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            ReadYamlStep readYamlStep = new ReadYamlStep();
+            readYamlStep.setDefaultCodePointLimit(ReadYamlStep.getMaxCodePointLimit() + 1);
+        });
+        String expectedMessage =
+                "Reduce the required DEFAULT_CODE_POINT_LIMIT or convince your administrator to increase";
+        String actualMessage = exception.getMessage();
+        assertTrue(
+                actualMessage.contains(expectedMessage),
+                actualMessage + " <<<< DOES NOT CONTAIN >>>> " + expectedMessage);
+    }
 
-	@Test
-	public void setDefaultCodePointLimitHigherThanMaxFailsWithException() throws Exception {
-		Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-			ReadYamlStep readYamlStep = new ReadYamlStep();
-			readYamlStep.setDefaultCodePointLimit(ReadYamlStep.getMaxCodePointLimit() + 1);
-		});
-		String expectedMessage = "Reduce the required DEFAULT_CODE_POINT_LIMIT or convince your administrator to increase";
-		String actualMessage = exception.getMessage();
-		assertTrue(actualMessage + " <<<< DOES NOT CONTAIN >>>> " + expectedMessage, actualMessage.contains(expectedMessage));
-	}
+    @Test
+    void millionLaughs() throws Exception {
+        final String lol =
+                """
+                a: &a ["lol","lol","lol","lol","lol","lol","lol","lol","lol"]
+                b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a]
+                c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b]
+                d: &d [*c,*c,*c,*c,*c,*c,*c,*c,*c]
+                e: &e [*d,*d,*d,*d,*d,*d,*d,*d,*d]
+                f: &f [*e,*e,*e,*e,*e,*e,*e,*e,*e]
+                g: &g [*f,*f,*f,*f,*f,*f,*f,*f,*f]
+                """ /* + //Not the full billion
+                                                                                                                                                                                                                                                                                                                                                                                                                                        "h: &h [*g,*g,*g,*g,*g,*g,*g,*g,*g]\n" +
+                                                                                                                                                                                                                                                                                                                                                                                                                                        "i: &i [*h,*h,*h,*h,*h,*h,*h,*h,*h]"*/;
+        File file = File.createTempFile("junit", null, temp);
+        FileUtils.writeStringToFile(file, lol, Charset.defaultCharset());
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node('" + j.jenkins.getSelfLabel() + "') { def yaml = readYaml file: '"
+                        + separatorsToSystemEscaped(file.getAbsolutePath()) + "'}",
+                true));
+        j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
+        p.setDefinition(new CpsFlowDefinition(
+                "node('" + j.jenkins.getSelfLabel() + "') { def yaml = readYaml maxAliasesForCollections: 500, file: '"
+                        + separatorsToSystemEscaped(file.getAbsolutePath()) + "'}",
+                true));
+        j.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0));
+    }
 
-	@Test
-	public void millionLaughs() throws Exception {
-		final String lol = "a: &a [\"lol\",\"lol\",\"lol\",\"lol\",\"lol\",\"lol\",\"lol\",\"lol\",\"lol\"]\n" +
-				"b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a]\n" +
-				"c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b]\n" +
-				"d: &d [*c,*c,*c,*c,*c,*c,*c,*c,*c]\n" +
-				"e: &e [*d,*d,*d,*d,*d,*d,*d,*d,*d]\n" +
-				"f: &f [*e,*e,*e,*e,*e,*e,*e,*e,*e]\n" +
-				"g: &g [*f,*f,*f,*f,*f,*f,*f,*f,*f]\n"/* + //Not the full billion
-				"h: &h [*g,*g,*g,*g,*g,*g,*g,*g,*g]\n" +
-				"i: &i [*h,*h,*h,*h,*h,*h,*h,*h,*h]"*/;
-		File file = temp.newFile();
-		FileUtils.writeStringToFile(file, lol, Charset.defaultCharset());
-		WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-		p.setDefinition(new CpsFlowDefinition(
-				"node('"+j.jenkins.getSelfLabel()+"') { def yaml = readYaml file: '" + separatorsToSystemEscaped(file.getAbsolutePath()) + "'}",
-				true));
-		j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
-		p.setDefinition(new CpsFlowDefinition(
-				"node('"+j.jenkins.getSelfLabel()+"') { def yaml = readYaml maxAliasesForCollections: 500, file: '" + separatorsToSystemEscaped(file.getAbsolutePath()) + "'}",
-				true));
-		j.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0));
-	}
+    @Test
+    void setMaxMaxFallingBackToUpperLimit() {
+        ReadYamlStep.setMaxMaxAliasesForCollections(ReadYamlStep.HARDCODED_CEILING_MAX_ALIASES_FOR_COLLECTIONS + 1);
+        assertEquals(
+                ReadYamlStep.HARDCODED_CEILING_MAX_ALIASES_FOR_COLLECTIONS,
+                ReadYamlStep.getMaxMaxAliasesForCollections());
+    }
 
-	@Test
-	public void setMaxMaxFallingBackToUpperLimit() throws Exception {
-		ReadYamlStep.setMaxMaxAliasesForCollections(ReadYamlStep.HARDCODED_CEILING_MAX_ALIASES_FOR_COLLECTIONS + 1);
-		assertEquals(ReadYamlStep.HARDCODED_CEILING_MAX_ALIASES_FOR_COLLECTIONS, ReadYamlStep.getMaxMaxAliasesForCollections());
-	}
+    @Test
+    void setDefaultHigherThanMaxFailsWithException() {
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            ReadYamlStep readYamlStep = new ReadYamlStep();
+            readYamlStep.setDefaultMaxAliasesForCollections(ReadYamlStep.getMaxMaxAliasesForCollections() + 1);
+        });
+        String expectedMessage =
+                "Reduce the required DEFAULT_MAX_ALIASES_FOR_COLLECTIONS or convince your administrator to increase";
+        String actualMessage = exception.getMessage();
+        assertTrue(
+                actualMessage.contains(expectedMessage),
+                actualMessage + " <<<< DOES NOT CONTAIN >>>> " + expectedMessage);
+    }
 
-	@Test
-	public void setDefaultHigherThanMaxFailsWithException() throws Exception {
-		Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-			ReadYamlStep readYamlStep = new ReadYamlStep();
-			readYamlStep.setDefaultMaxAliasesForCollections(ReadYamlStep.getMaxMaxAliasesForCollections() + 1);
-		});
-		String expectedMessage = "Reduce the required DEFAULT_MAX_ALIASES_FOR_COLLECTIONS or convince your administrator to increase";
-		String actualMessage = exception.getMessage();
-		assertTrue(actualMessage + " <<<< DOES NOT CONTAIN >>>> " + expectedMessage, actualMessage.contains(expectedMessage));
-	}
+    @Test
+    void setDefaultHigherThanHardcodedMaxFailsWithException() {
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            ReadYamlStep readYamlStep = new ReadYamlStep();
+            readYamlStep.setDefaultMaxAliasesForCollections(
+                    ReadYamlStep.HARDCODED_CEILING_MAX_ALIASES_FOR_COLLECTIONS + 1);
+        });
+        String expectedMessage = "Hardcoded upper limit breached";
+        String actualMessage = exception.getMessage();
+        assertTrue(
+                actualMessage.contains(expectedMessage),
+                actualMessage + " <<<< DOES NOT CONTAIN >>>> " + expectedMessage);
+    }
 
-	@Test
-	public void setDefaultHigherThanHardcodedMaxFailsWithException() throws Exception {
-		Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-			ReadYamlStep readYamlStep = new ReadYamlStep();
-			readYamlStep.setDefaultMaxAliasesForCollections(ReadYamlStep.HARDCODED_CEILING_MAX_ALIASES_FOR_COLLECTIONS + 1);
-		});
-		String expectedMessage = "Hardcoded upper limit breached";
-		String actualMessage = exception.getMessage();
-		assertTrue(actualMessage + " <<<< DOES NOT CONTAIN >>>> " + expectedMessage, actualMessage.contains(expectedMessage));
-	}
-
-	@Test
-	public void readNone() throws Exception {
-		WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-		p.setDefinition(new CpsFlowDefinition("node('slaves') {\n" + "  def props = readYaml()\n" + "}", true));
-		WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
-		j.assertLogContains(Messages.AbstractFileOrTextStepDescriptorImpl_missingRequiredArgument("readYaml"), run);
-	}
+    @Test
+    void readNone() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                """
+                node('slaves') {
+                  def props = readYaml()
+                }""",
+                true));
+        WorkflowRun run =
+                j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+        j.assertLogContains(Messages.AbstractFileOrTextStepDescriptorImpl_missingRequiredArgument("readYaml"), run);
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStepTest.java
@@ -1,10 +1,11 @@
 package org.jenkinsci.plugins.pipeline.utility.steps.conf;
 
-import hudson.model.Label;
-import hudson.model.Result;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
+
+import hudson.model.Label;
+import hudson.model.Result;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
 import org.jenkinsci.plugins.workflow.actions.ArgumentsAction;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
@@ -12,249 +13,277 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.graphanalysis.DepthFirstScanner;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.jvnet.hudson.test.BuildWatcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class WriteYamlStepTest {
+@WithJenkins
+class WriteYamlStepTest {
 
-    @ClassRule
-    public static BuildWatcher bw = new BuildWatcher();
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
-    @Rule
-    public TemporaryFolder temp = new TemporaryFolder();
+    private JenkinsRule j;
 
-    @Before
-    public void setup() throws Exception {
+    @BeforeEach
+    void setUp(JenkinsRule rule) throws Exception {
+        j = rule;
         j.createOnlineSlave(Label.get("slaves"));
     }
 
     @Test
-    public void writeInvalidMap() throws Exception {
+    void writeInvalidMap() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "def l = [] \n" +
-                        "node('slaves') {\n" +
-                        "  writeYaml file: 'test', data: /['a': ]/ \n" +
-                        "  def yml = readYaml file: 'test' \n" +
-                        "  assert yml == /['a': ]/ \n" +
-                        "}",
-                true));
-        WorkflowRun b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
-    }
-
-        @Test
-        public void writeArbitraryObject() throws Exception {
-                WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-                p.setDefinition(new CpsFlowDefinition(
-                 "def l = [] \n" +
-                        "node('slaves') {\n" +
-                                                "   writeYaml file: 'test', data: new Date() \n" +
-                         "  def yml = readYaml file: 'test' \n" +
-                         "  assert yml =~ /2\\d{3}/ \n" +
-                                                "}",
-                                true));
-        WorkflowRun b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
-        }
-
-    @Test
-    public void writeMapObject() throws Exception {
-                WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "map");
-                p.setDefinition(new CpsFlowDefinition(
-                                  "node('slaves') {\n" +
-                                                 "  writeYaml file: 'test', data: ['a': 1, 'b': 2] \n" +
-                         "  def yml = readYaml file: 'test' \n" +
-                         "  assert yml == ['a' : 1, 'b': 2] \n" +
-                                                 "}",
-                                true));
-                WorkflowRun b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
-    }
-
-    @Test
-    public void writeListObjectAndRead() throws Exception {
-        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "list");
-        p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  writeYaml file: 'test', data: ['a', 'b', 'c'] \n" +
-                        "  def yml = readYaml file: 'test' \n" +
-                        "  assert yml == ['a','b','c'] \n"+
-                        "}",
+                """
+                        def l = []
+                        node('slaves') {
+                          writeYaml file: 'test', data: /['a': ]/
+                          def yml = readYaml file: 'test'
+                          assert yml == /['a': ]/
+                        }""",
                 true));
         WorkflowRun b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void writeListOfDocumentsAndRead() throws Exception {
-        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "list");
+    void writeArbitraryObject() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  writeYaml file: 'test', datas: [['a': 1, 'b': 2], ['a': 3, 'b': 4]] \n" +
-                        "  def yml = readYaml file: 'test' \n" +
-                        "  assert yml == [['a': 1, 'b': 2], ['a': 3, 'b': 4]] \n"+
-                        "}",
+                """
+                                def l = []
+                                node('slaves') {
+                                   writeYaml file: 'test', data: new Date()
+                                  def yml = readYaml file: 'test'
+                                  assert yml =~ /2\\d{3}/
+                                }""",
                 true));
         WorkflowRun b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void writeExistingFile() throws Exception {
+    void writeMapObject() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "map");
+        p.setDefinition(new CpsFlowDefinition(
+                """
+                                node('slaves') {
+                                  writeYaml file: 'test', data: ['a': 1, 'b': 2]
+                                  def yml = readYaml file: 'test'
+                                  assert yml == ['a' : 1, 'b': 2]
+                                }""",
+                true));
+        WorkflowRun b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    }
+
+    @Test
+    void writeListObjectAndRead() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "list");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  touch 'test.yml' \n" +
-                        "  writeYaml file: 'test.yml', data: ['a', 'b', 'c'] \n" +
-                        "}",
+                """
+                        node('slaves') {
+                          writeYaml file: 'test', data: ['a', 'b', 'c']
+                          def yml = readYaml file: 'test'
+                          assert yml == ['a','b','c']
+                        }""",
+                true));
+        WorkflowRun b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    }
+
+    @Test
+    void writeListOfDocumentsAndRead() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "list");
+        p.setDefinition(new CpsFlowDefinition(
+                """
+                        node('slaves') {
+                          writeYaml file: 'test', datas: [['a': 1, 'b': 2], ['a': 3, 'b': 4]]
+                          def yml = readYaml file: 'test'
+                          assert yml == [['a': 1, 'b': 2], ['a': 3, 'b': 4]]
+                        }""",
+                true));
+        WorkflowRun b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    }
+
+    @Test
+    void writeExistingFile() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "list");
+        p.setDefinition(new CpsFlowDefinition(
+                """
+                        node('slaves') {
+                          touch 'test.yml'
+                          writeYaml file: 'test.yml', data: ['a', 'b', 'c']
+                        }""",
                 true));
         WorkflowRun b = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
         j.assertLogContains("FileAlreadyExistsException", b);
     }
 
     @Test
-    public void overwriteExistingFile() throws Exception {
+    void overwriteExistingFile() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "list");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  writeFile file: 'test.yml', text: 'overwrite me' \n" +
-                        "  writeYaml file: 'test.yml', overwrite: true, data: 'overwritten' \n" +
-                        "  final text = readFile file: 'test.yml' \n" +
-                        "  if (text != 'overwritten\\n') error('got ' + text) \n" +
-                        "}",
+                """
+                        node('slaves') {
+                          writeFile file: 'test.yml', text: 'overwrite me'
+                          writeYaml file: 'test.yml', overwrite: true, data: 'overwritten'
+                          final text = readFile file: 'test.yml'
+                          if (text != 'overwritten\\n') error('got ' + text)
+                        }""",
                 true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void writeGStringWithoutApproval() throws Exception {
+    void writeGStringWithoutApproval() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "gstringjobnoapproval");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  writeYaml file: 'test', data: \"${currentBuild.rawBuild}\" \n" +
-                        "  def yml = readYaml file: 'test' \n" +
-                        "  assert yml == 'gstringjob#1' \n"+
-                        "}",
+                """
+                        node('slaves') {
+                          writeYaml file: 'test', data: "${currentBuild.rawBuild}"
+                          def yml = readYaml file: 'test'
+                          assert yml == 'gstringjob#1'
+                        }""",
                 true));
         WorkflowRun b = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
-        j.assertLogContains("Scripts not permitted to use method org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper getRawBuild", b);
+        j.assertLogContains(
+                "Scripts not permitted to use method org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper getRawBuild",
+                b);
     }
 
     @Test
-    public void writeGString() throws Exception {
+    void writeGString() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "gstringjob");
         final ScriptApproval approval = ScriptApproval.get();
         approval.approveSignature("method org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper getRawBuild");
         approval.approveSignature("method hudson.model.Run getExternalizableId");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  writeYaml file: 'test', data: \"${currentBuild.rawBuild.externalizableId}\" \n" +
-                        "  def yml = readYaml file: 'test' \n" +
-                        "  echo yml \n"+
-                        "  assert yml == 'gstringjob#1' \n"+
-                        "}",
+                """
+                        node('slaves') {
+                          writeYaml file: 'test', data: "${currentBuild.rawBuild.externalizableId}"
+                          def yml = readYaml file: 'test'
+                          echo yml
+                          assert yml == 'gstringjob#1'
+                        }""",
                 true));
         WorkflowRun b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-     public void writeNoData() throws Exception {
+    void writeNoData() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition("node('slaves') {\n" + "  writeYaml file: 'some' \n" + "}", true));
-        WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+        p.setDefinition(new CpsFlowDefinition(
+                """
+                node('slaves') {
+                  writeYaml file: 'some'
+                }""",
+                true));
+        WorkflowRun run =
+                j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
         j.assertLogContains("data or datas parameter must be provided to writeYaml", run);
     }
 
     @Test
-     public void writeDataAndDatas() throws Exception {
+    void writeDataAndDatas() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-         p.setDefinition(new CpsFlowDefinition(
-                 "node('slaves') {\n" +
-                         "  writeYaml file: 'test', data: ['a': 1, 'b': 2], datas: [['a': 1], ['b': 2]] \n" +
-                         "}",
-                 true));
-        WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+        p.setDefinition(new CpsFlowDefinition(
+                """
+                         node('slaves') {
+                           writeYaml file: 'test', data: ['a': 1, 'b': 2], datas: [['a': 1], ['b': 2]]
+                         }""",
+                true));
+        WorkflowRun run =
+                j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
         j.assertLogContains("only one of data or datas must be provided to writeYaml", run);
     }
 
     @Test
-    public void writeNoFile() throws Exception {
+    void writeNoFile() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition("node('slaves') {\n" + "  writeYaml data: 'some', file: '' \n" + "}", true));
-        WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+        p.setDefinition(new CpsFlowDefinition(
+                """
+                node('slaves') {
+                  writeYaml data: 'some', file: ''
+                }""",
+                true));
+        WorkflowRun run =
+                j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
         j.assertLogContains("either file or returnText must be provided to writeYaml", run);
     }
 
     @Test
-    public void invalidDataObject() throws Exception {
+    void invalidDataObject() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "list");
         ScriptApproval.get().approveSignature("staticMethod java.util.TimeZone getDefault");
         p.setDefinition(new CpsFlowDefinition(
-                        "node('slaves') {\n" +
-                        "  def tz = TimeZone.getDefault() \n" +
-                        "  echo \"${tz}\"  \n" +
-                        "  writeYaml file: 'test', data: TimeZone.getDefault()\n" +
-                        "}",
+                """
+                        node('slaves') {
+                          def tz = TimeZone.getDefault()
+                          echo "${tz}"
+                          writeYaml file: 'test', data: TimeZone.getDefault()
+                        }""",
                 true));
         WorkflowRun b = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
         j.assertLogContains("data parameter has invalid content (no-basic classes)", b);
     }
 
     @Test
-    public void validComplexDataObject() throws Exception {
+    void validComplexDataObject() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "list");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  def data = [['a': 1, 'b' : '2', true: false], true, null, 'some string value'] \n" +
-                        "  echo(/${data.toString().toUpperCase()}/)\n" +
-                        "  writeYaml file: 'test', data: data\n" +
-                        "}",
+                """
+                        node('slaves') {
+                          def data = [['a': 1, 'b' : '2', true: false], true, null, 'some string value']
+                          echo(/${data.toString().toUpperCase()}/)
+                          writeYaml file: 'test', data: data
+                        }""",
                 true));
         WorkflowRun b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         for (FlowNode n : new DepthFirstScanner().allNodes(b.getExecution())) {
             String args = ArgumentsAction.getStepArgumentsAsString(n);
-            assertThat("saved full YAML `" + args + "` in " + n + " ~ " + n.getDisplayName(), args, not(containsString("some string value")));
+            assertThat(
+                    "saved full YAML `" + args + "` in " + n + " ~ " + n.getDisplayName(),
+                    args,
+                    not(containsString("some string value")));
             // Note that ArgumentsAction.getArguments(n) shows that the FlowNode stores the original object.
         }
     }
 
     @Test
-    public void invalidComplexDataObject() throws Exception {
+    void invalidComplexDataObject() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "list");
         ScriptApproval.get().approveSignature("staticMethod java.util.TimeZone getDefault");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  def data = [true, null, ['a': 1, 'b' : '2', true: false, 'tz': TimeZone.getDefault()], 'str'] \n" +
-                        "  echo \"${data}\"  \n" +
-                        "  writeYaml file: 'test', data: data\n" +
-                        "}",
+                """
+                        node('slaves') {
+                          def data = [true, null, ['a': 1, 'b' : '2', true: false, 'tz': TimeZone.getDefault()], 'str']
+                          echo "${data}"
+                          writeYaml file: 'test', data: data
+                        }""",
                 true));
         WorkflowRun b = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
         j.assertLogContains("data parameter has invalid content (no-basic classes)", b);
     }
 
     @Test
-    public void returnText() throws Exception {
-                WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "map");
-                p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  String written = writeYaml returnText: true, data: ['a': 1, 'b': 2] \n" +
-                        "  def yml = readYaml text: written \n" +
-                        "  assert yml == ['a' : 1, 'b': 2] \n" +
-                        "}",
+    void returnText() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "map");
+        p.setDefinition(new CpsFlowDefinition(
+                """
+                                node('slaves') {
+                                  String written = writeYaml returnText: true, data: ['a': 1, 'b': 2]
+                                  def yml = readYaml text: written
+                                  assert yml == ['a' : 1, 'b': 2]
+                                }""",
                 true));
         WorkflowRun b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void returnTextWithoutNode() throws Exception {
-                WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "map");
-                p.setDefinition(new CpsFlowDefinition(
-                "String written = writeYaml returnText: true, data: ['a': 1, 'b': 2] \n" +
-                "def yml = readYaml text: written \n" +
-                "assert yml == ['a' : 1, 'b': 2] \n",
+    void returnTextWithoutNode() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "map");
+        p.setDefinition(new CpsFlowDefinition(
+                """
+                                String written = writeYaml returnText: true, data: ['a': 1, 'b': 2]
+                                def yml = readYaml text: written
+                                assert yml == ['a' : 1, 'b': 2]
+                                """,
                 true));
         WorkflowRun b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStepUnitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStepUnitTest.java
@@ -1,40 +1,36 @@
 package org.jenkinsci.plugins.pipeline.utility.steps.conf;
 
-import org.junit.Test;
-import org.jvnet.hudson.test.WithoutJenkins;
-import org.yaml.snakeyaml.Yaml;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertThrows;
+class WriteYamlStepUnitTest {
 
-public class WriteYamlStepUnitTest {
     @Test
-    @WithoutJenkins
-    public void writeEmptyListObject() {
+    void writeEmptyListObject() {
         WriteYamlStep writeStep = new WriteYamlStep("/dev/null", new ArrayList<>());
     }
 
     @Test
-    @WithoutJenkins
-    public void writeEmptyListOfDocuments() {
+    void writeEmptyListOfDocuments() {
         WriteYamlStep writeStep = new WriteYamlStep("/dev/null");
         writeStep.setDatas(new ArrayList<>());
     }
 
     @Test
-    @WithoutJenkins
-    public void writeInvalidObject() {
-        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> new WriteYamlStep("/dev/null", new Yaml()));
+    void writeInvalidObject() {
+        IllegalArgumentException thrown =
+                assertThrows(IllegalArgumentException.class, () -> new WriteYamlStep("/dev/null", new Yaml()));
         assertThat(thrown.getMessage(), equalTo("data parameter has invalid content (no-basic classes)"));
     }
 
     @Test
-    @WithoutJenkins
-    public void writeInvalidDocuments() {
+    void writeInvalidDocuments() {
         IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> {
             WriteYamlStep writeStep = new WriteYamlStep("/dev/null");
             writeStep.setDatas(new ArrayList<>(Collections.singletonList(new Yaml())));

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/csv/ReadCSVStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/csv/ReadCSVStepTest.java
@@ -24,13 +24,15 @@
 
 package org.jenkinsci.plugins.pipeline.utility.steps.conf.csv;
 
+import static org.jenkinsci.plugins.pipeline.utility.steps.Messages.AbstractFileOrTextStepDescriptorImpl_missingRequiredArgument;
+
+import hudson.model.Result;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.Writer;
-
 import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.pipeline.utility.steps.FilenameTestsUtils;
 import org.jenkinsci.plugins.pipeline.utility.steps.csv.Messages;
@@ -38,105 +40,114 @@ import org.jenkinsci.plugins.pipeline.utility.steps.csv.ReadCSVStep;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import hudson.model.Result;
-
-import static org.jenkinsci.plugins.pipeline.utility.steps.Messages.AbstractFileOrTextStepDescriptorImpl_missingRequiredArgument;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 /**
  * Tests for {@link ReadCSVStep}.
  *
  * @author Stuart Rowe
  */
-public class ReadCSVStepTest {
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
-    @Rule
-    public TemporaryFolder temp = new TemporaryFolder();
+@WithJenkins
+class ReadCSVStepTest {
+
+    private JenkinsRule j;
+
+    @TempDir
+    private File temp;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) {
+        j = rule;
+    }
 
     @Test
-    public void readFile() throws Exception {
+    void readFile() throws Exception {
         String file = writeCSV(getCSV());
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                "  List<CSVRecord> records = readCSV file: '" + file + "'\n" +
-                "  assert records.size() == 3\n" +
-                "  assert records[0].get(0) == 'key'\n" +
-                "  assert records[1].get(1) == 'b'\n" +
-                "  assert records[2].get(2) == '3'\n" +
-                "}", true));
+                "node {\n" + "  List<CSVRecord> records = readCSV file: '"
+                        + file + "'\n" + "  assert records.size() == 3\n"
+                        + "  assert records[0].get(0) == 'key'\n"
+                        + "  assert records[1].get(1) == 'b'\n"
+                        + "  assert records[2].get(2) == '3'\n"
+                        + "}",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void readDirectText() throws Exception {
+    void readDirectText() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                "  def recordsString = \"key,value,attr\\na,b,c\\n1,2,3\\n\"\n" +
-                "  List<CSVRecord> records = readCSV text: recordsString\n" +
-                "  assert records.size() == 3\n" +
-                "  assert records[0].get(0) == 'key'\n" +
-                "  assert records[1].get(1) == 'b'\n" +
-                "  assert records[2].get(2) == '3'\n" +
-                "}", true));
+                """
+                        node {
+                          def recordsString = "key,value,attr\\na,b,c\\n1,2,3\\n"
+                          List<CSVRecord> records = readCSV text: recordsString
+                          assert records.size() == 3
+                          assert records[0].get(0) == 'key'
+                          assert records[1].get(1) == 'b'
+                          assert records[2].get(2) == '3'
+                        }""",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void readNone() throws Exception {
+    void readNone() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                "  List<CSVRecord> records = readCSV()\n" +
-                "}", true));
+                """
+                        node {
+                          List<CSVRecord> records = readCSV()
+                        }""",
+                true));
         WorkflowRun run = p.scheduleBuild2(0).get();
         j.assertBuildStatus(Result.FAILURE, run);
         j.assertLogContains(AbstractFileOrTextStepDescriptorImpl_missingRequiredArgument("readCSV"), run);
     }
 
     @Test
-    public void readFileAndText() throws Exception {
+    void readFileAndText() throws Exception {
         String file = writeCSV(getCSV());
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                "  def recordsString = \"key,value,attr\\na,b,c\\n1,2,3\\n\"\n" +
-                "  List<CSVRecord> records = readCSV text: recordsString, file: '" + file + "'\n" +
-                "  assert records.size() == 3\n" +
-                "  assert records[0].get(0) == 'key'\n" +
-                "  assert records[1].get(1) == 'b'\n" +
-                "  assert records[2].get(2) == '3'\n" +
-                "}", true));
+                "node {\n" + "  def recordsString = \"key,value,attr\\na,b,c\\n1,2,3\\n\"\n"
+                        + "  List<CSVRecord> records = readCSV text: recordsString, file: '"
+                        + file + "'\n" + "  assert records.size() == 3\n"
+                        + "  assert records[0].get(0) == 'key'\n"
+                        + "  assert records[1].get(1) == 'b'\n"
+                        + "  assert records[2].get(2) == '3'\n"
+                        + "}",
+                true));
         WorkflowRun run = p.scheduleBuild2(0).get();
         j.assertBuildStatus(Result.FAILURE, run);
         j.assertLogContains(Messages.ReadCSVStepExecution_tooManyArguments("readCSV"), run);
     }
 
-     @Test
-    public void readFileWithFormat() throws Exception {
+    @Test
+    void readFileWithFormat() throws Exception {
         String file = writeCSV(getCSV());
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                "  def format = CSVFormat.EXCEL.withHeader('key', 'value', 'attr').withSkipHeaderRecord(true)\n" +
-                "  List<CSVRecord> records = readCSV file: '" + file + "', format: format\n" +
-                "  assert records.size() == 2\n" +
-                "  assert records[0].get('key') == 'a'\n" +
-                "  assert records[0].get('value') == 'b'\n" +
-                "  assert records[0].get('attr') == 'c'\n" +
-                "  assert records[1].get('key') == '1'\n" +
-                "  assert records[1].get('value') == '2'\n" +
-                "  assert records[1].get('attr') == '3'\n" +
-                "}", true));
+                "node {\n"
+                        + "  def format = CSVFormat.EXCEL.withHeader('key', 'value', 'attr').withSkipHeaderRecord(true)\n"
+                        + "  List<CSVRecord> records = readCSV file: '"
+                        + file + "', format: format\n" + "  assert records.size() == 2\n"
+                        + "  assert records[0].get('key') == 'a'\n"
+                        + "  assert records[0].get('value') == 'b'\n"
+                        + "  assert records[0].get('attr') == 'c'\n"
+                        + "  assert records[1].get('key') == '1'\n"
+                        + "  assert records[1].get('value') == '2'\n"
+                        + "  assert records[1].get('attr') == '3'\n"
+                        + "}",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
@@ -148,15 +159,15 @@ public class ReadCSVStepTest {
     }
 
     private String getCSV() {
-       return getCSV(',');
+        return getCSV(',');
     }
 
     private String writeCSV(String csv) throws IOException {
-        File file = temp.newFile();
-        try (Writer f = new FileWriter(file); Reader r = new StringReader(csv)) {
+        File file = File.createTempFile("junit", null, temp);
+        try (Writer f = new FileWriter(file);
+                Reader r = new StringReader(csv)) {
             IOUtils.copy(r, f);
         }
         return FilenameTestsUtils.toPath(file);
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha1VerifyStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha1VerifyStepTest.java
@@ -6,89 +6,101 @@ import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class FileSha1VerifyStepTest {
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class FileSha1VerifyStepTest {
 
-    @Before
-    public void setup() throws Exception {
+    private JenkinsRule j;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) throws Exception {
+        j = rule;
         j.createOnlineSlave(Label.get("slaves"));
     }
 
     @Test
-    public void configRoundTrip() throws Exception {
+    void configRoundTrip() throws Exception {
         FileVerifySha1Step step = new FileVerifySha1Step("f.txt", "hash");
         FileVerifySha1Step step2 = new StepConfigTester(j).configRoundTrip(step);
         j.assertEqualDataBoundBeans(step, step2);
     }
 
     @Test
-    public void emptyFile() throws Exception {
+    void emptyFile() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  dir('test') {\n" +
-                        "    touch 'empty.txt'\n" +
-                        "    verifySha1(file: 'empty.txt', hash: 'da39a3ee5e6b4b0d3255bfef95601890afd80709')\n" +
-                        "  }\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          dir('test') {
+                            touch 'empty.txt'
+                            verifySha1(file: 'empty.txt', hash: 'da39a3ee5e6b4b0d3255bfef95601890afd80709')
+                          }
+                        }""",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void ignoresHashCase() throws Exception {
+    void ignoresHashCase() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  dir('test') {\n" +
-                        "    touch 'empty.txt'\n" +
-                        "    verifySha1(file: 'empty.txt', hash: 'DA39A3EE5E6B4B0D3255BFEF95601890AFD80709')\n" +
-                        "  }\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          dir('test') {
+                            touch 'empty.txt'
+                            verifySha1(file: 'empty.txt', hash: 'DA39A3EE5E6B4B0D3255BFEF95601890AFD80709')
+                          }
+                        }""",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void fileWithContent() throws Exception {
+    void fileWithContent() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  dir('test') {\n" +
-                        "    writeFile file: 'f.txt', text: 'abc', encoding: 'UTF-8'\n" +
-                        "    verifySha1(file: 'f.txt', hash: 'a9993e364706816aba3e25717850c26c9cd0d89d')\n" +
-                        "  }\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          dir('test') {
+                            writeFile file: 'f.txt', text: 'abc', encoding: 'UTF-8'
+                            verifySha1(file: 'f.txt', hash: 'a9993e364706816aba3e25717850c26c9cd0d89d')
+                          }
+                        }""",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void failsOnMismatch() throws Exception {
+    void failsOnMismatch() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  dir('test') {\n" +
-                        "    writeFile file: 'fail.txt', text: 'should fail with invalid hash', encoding: 'UTF-8'\n" +
-                        "    verifySha1(file: 'fail.txt', hash: 'a9993e364706816aba3e25717850c26c9cd0d89d')\n" +
-                        "  }\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          dir('test') {
+                            writeFile file: 'fail.txt', text: 'should fail with invalid hash', encoding: 'UTF-8'
+                            verifySha1(file: 'fail.txt', hash: 'a9993e364706816aba3e25717850c26c9cd0d89d')
+                          }
+                        }""",
+                true));
         final WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
         j.assertLogContains("SHA1 hash mismatch", run);
     }
 
     @Test
-    public void failsIfFileNotFound() throws Exception {
+    void failsIfFileNotFound() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  dir('test') {\n" +
-                        "    verifySha1(file: 'nonexistent.txt', hash: 'a9993e364706816aba3e25717850c26c9cd0d89d')\n" +
-                        "  }\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          dir('test') {
+                            verifySha1(file: 'nonexistent.txt', hash: 'a9993e364706816aba3e25717850c26c9cd0d89d')
+                          }
+                        }""",
+                true));
         final WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
         j.assertLogContains("File not found: nonexistent.txt", run);
     }

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha256StepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha256StepTest.java
@@ -4,65 +4,73 @@ import hudson.model.Label;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class FileSha256StepTest {
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class FileSha256StepTest {
 
-    @Before
-    public void setup() throws Exception {
+    private JenkinsRule j;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) throws Exception {
+        j = rule;
         j.createOnlineSlave(Label.get("slaves"));
     }
 
     @Test
-    public void configRoundTrip() throws Exception {
+    void configRoundTrip() throws Exception {
         FileSha256Step step = new FileSha256Step("dir/f.txt");
         FileSha256Step step2 = new StepConfigTester(j).configRoundTrip(step);
         j.assertEqualDataBoundBeans(step, step2);
     }
 
     @Test
-    public void emptyFile() throws Exception {
+    void emptyFile() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  dir('test') {\n" +
-                        "    touch 'empty.txt'\n" +
-                        "    def hash = sha256 'empty.txt'\n" +
-                        "    assert hash == 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'\n" +
-                        "  }\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          dir('test') {
+                            touch 'empty.txt'
+                            def hash = sha256 'empty.txt'
+                            assert hash == 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+                          }
+                        }""",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void fileWithContent() throws Exception {
+    void fileWithContent() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  dir('test') {\n" +
-                        "    writeFile file: 'f.txt', text: 'abc', encoding: 'UTF-8'\n" +
-                        "    def hash = sha256 'f.txt'\n" +
-                        "    assert hash == 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'\n" +
-                        "  }\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          dir('test') {
+                            writeFile file: 'f.txt', text: 'abc', encoding: 'UTF-8'
+                            def hash = sha256 'f.txt'
+                            assert hash == 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'
+                          }
+                        }""",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void returnsNullIfFileNotFound() throws Exception {
+    void returnsNullIfFileNotFound() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  dir('test') {\n" +
-                        "    def hash = sha256 'not_existing.txt'\n" +
-                        "    assert hash == null\n" +
-                        "  }\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          dir('test') {
+                            def hash = sha256 'not_existing.txt'
+                            assert hash == null
+                          }
+                        }""",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha256VerifyStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha256VerifyStepTest.java
@@ -6,89 +6,101 @@ import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class FileSha256VerifyStepTest {
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class FileSha256VerifyStepTest {
 
-    @Before
-    public void setup() throws Exception {
+    private JenkinsRule j;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) throws Exception {
+        j = rule;
         j.createOnlineSlave(Label.get("slaves"));
     }
 
     @Test
-    public void configRoundTrip() throws Exception {
+    void configRoundTrip() throws Exception {
         FileVerifySha256Step step = new FileVerifySha256Step("f.txt", "hash");
         FileVerifySha256Step step2 = new StepConfigTester(j).configRoundTrip(step);
         j.assertEqualDataBoundBeans(step, step2);
     }
 
     @Test
-    public void emptyFile() throws Exception {
+    void emptyFile() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  dir('test') {\n" +
-                        "    touch 'empty.txt'\n" +
-                        "    verifySha256(file: 'empty.txt', hash: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')\n" +
-                        "  }\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          dir('test') {
+                            touch 'empty.txt'
+                            verifySha256(file: 'empty.txt', hash: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
+                          }
+                        }""",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void ignoresHashCase() throws Exception {
+    void ignoresHashCase() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  dir('test') {\n" +
-                        "    touch 'empty.txt'\n" +
-                        "    verifySha256(file: 'empty.txt', hash: 'E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855')\n" +
-                        "  }\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          dir('test') {
+                            touch 'empty.txt'
+                            verifySha256(file: 'empty.txt', hash: 'E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855')
+                          }
+                        }""",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void fileWithContent() throws Exception {
+    void fileWithContent() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  dir('test') {\n" +
-                        "    writeFile file: 'f.txt', text: 'abc', encoding: 'UTF-8'\n" +
-                        "    verifySha256(file: 'f.txt', hash: 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')\n" +
-                        "  }\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          dir('test') {
+                            writeFile file: 'f.txt', text: 'abc', encoding: 'UTF-8'
+                            verifySha256(file: 'f.txt', hash: 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')
+                          }
+                        }""",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void failsOnMismatch() throws Exception {
+    void failsOnMismatch() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  dir('test') {\n" +
-                        "    writeFile file: 'fail.txt', text: 'should fail with invalid hash', encoding: 'UTF-8'\n" +
-                        "    verifySha256(file: 'fail.txt', hash: 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')\n" +
-                        "  }\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          dir('test') {
+                            writeFile file: 'fail.txt', text: 'should fail with invalid hash', encoding: 'UTF-8'
+                            verifySha256(file: 'fail.txt', hash: 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')
+                          }
+                        }""",
+                true));
         final WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
         j.assertLogContains("SHA-256 hash mismatch", run);
     }
 
     @Test
-    public void failsIfFileNotFound() throws Exception {
+    void failsIfFileNotFound() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  dir('test') {\n" +
-                        "    verifySha256(file: 'nonexistent.txt', hash: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')\n" +
-                        "  }\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          dir('test') {
+                            verifySha256(file: 'nonexistent.txt', hash: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
+                          }
+                        }""",
+                true));
         final WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
         j.assertLogContains("File not found: nonexistent.txt", run);
     }

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/TeeStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/TeeStepTest.java
@@ -24,6 +24,9 @@
 
 package org.jenkinsci.plugins.pipeline.utility.steps.fs;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.stringContainsInOrder;
+
 import hudson.Functions;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Result;
@@ -34,15 +37,12 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.ClassRule;
-import org.junit.Test;
 import org.junit.Rule;
+import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsSessionRule;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.stringContainsInOrder;
 
 public class TeeStepTest {
 
@@ -55,31 +55,36 @@ public class TeeStepTest {
     @Test
     public void smokes() throws Throwable {
         sessions.then(r -> {
-                r.createSlave("remote", null, null);
-                WorkflowJob p = r.createProject(WorkflowJob.class, "p");
-                // Remote FS gets blown away during restart, alas; need JenkinsRule utility for stable agent workspace:
-                p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("WS", r.jenkins.getWorkspaceFor(p).getRemote())));
-                p.setDefinition(new CpsFlowDefinition(
-                        "node('remote') {\n" +
-                        "  dir(params.WS) {\n" +
-                        "    tee('x.log') {\n" +
-                        "      echo 'first message'\n" +
-                        "      semaphore 'wait'\n" +
-                        "      echo 'second message'\n" +
-                        "      if (isUnix()) {sh 'true'} else {bat 'rem'}\n" +
-                        "    }\n" +
-                        "    echo(/got: ${readFile('x.log').trim().replaceAll('\\\\s+', ' ').replace(pwd(), 'WS')}/)\n" +
-                        "  }\n" +
-                        "}", true));
-                WorkflowRun b = p.scheduleBuild2(0).waitForStart();
-                SemaphoreStep.waitForStart("wait/1", b);
+            r.createSlave("remote", null, null);
+            WorkflowJob p = r.createProject(WorkflowJob.class, "p");
+            // Remote FS gets blown away during restart, alas; need JenkinsRule utility for stable agent workspace:
+            p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition(
+                    "WS", r.jenkins.getWorkspaceFor(p).getRemote())));
+            p.setDefinition(new CpsFlowDefinition(
+                    """
+                                node('remote') {
+                                  dir(params.WS) {
+                                    tee('x.log') {
+                                      echo 'first message'
+                                      semaphore 'wait'
+                                      echo 'second message'
+                                      if (isUnix()) {sh 'true'} else {bat 'rem'}
+                                    }
+                                    echo(/got: ${readFile('x.log').trim().replaceAll('\\\\s+', ' ').replace(pwd(), 'WS')}/)
+                                  }
+                                }""",
+                    true));
+            WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+            SemaphoreStep.waitForStart("wait/1", b);
         });
         sessions.then(r -> {
-                SemaphoreStep.success("wait/1", null);
-                WorkflowRun b = r.jenkins.getItemByFullName("p", WorkflowJob.class).getBuildByNumber(1);
-                r.assertBuildStatus(Result.SUCCESS, r.waitForCompletion(b));
-                assertThat(JenkinsRule.getLog(b), stringContainsInOrder("got: first message second message", Functions.isWindows() ? "WS>rem" : "+ true"));
-
+            SemaphoreStep.success("wait/1", null);
+            WorkflowRun b = r.jenkins.getItemByFullName("p", WorkflowJob.class).getBuildByNumber(1);
+            r.assertBuildStatus(Result.SUCCESS, r.waitForCompletion(b));
+            assertThat(
+                    JenkinsRule.getLog(b),
+                    stringContainsInOrder(
+                            "got: first message second message", Functions.isWindows() ? "WS>rem" : "+ true"));
         });
     }
 
@@ -90,14 +95,16 @@ public class TeeStepTest {
             r.createSlave("remote", null, null);
             WorkflowJob p = r.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition(
-                    "node('remote') {\n" +
-                            "  tee('x.log') {\n" +
-                            "    echo 'first message'\n" +
-                            "  }\n" +
-                            "  if (isUnix()) {sh 'rm x.log'} else {bat 'del x.log'}\n" +
-                            "  writeFile file: 'x.log', text: 'second message'\n" +
-                            "  echo(/got: ${readFile('x.log').trim().replaceAll('\\\\s+', ' ')}/)\n" +
-                            "}", true));
+                    """
+                            node('remote') {
+                              tee('x.log') {
+                                echo 'first message'
+                              }
+                              if (isUnix()) {sh 'rm x.log'} else {bat 'del x.log'}
+                              writeFile file: 'x.log', text: 'second message'
+                              echo(/got: ${readFile('x.log').trim().replaceAll('\\\\s+', ' ')}/)
+                            }""",
+                    true));
             WorkflowRun b = p.scheduleBuild2(0).waitForStart();
             r.assertBuildStatus(Result.SUCCESS, r.waitForCompletion(b));
             r.assertLogContains("got: second message", b);
@@ -111,16 +118,18 @@ public class TeeStepTest {
             r.createSlave("remote", null, null);
             WorkflowJob p = r.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition(
-                    "node('remote') {\n" +
-                            "  tee('x.log') {\n" +
-                            "    if (isUnix()) { sh 'echo first message' } else { bat 'echo first message' }\n" +
-                            "    semaphore 'wait'\n" +
-                            "    if (isUnix()) { sh 'echo second message' } else { bat 'echo second message' }\n" +
-                            "  }\n" +
-                            "  if (isUnix()) {sh 'rm x.log'} else {bat 'del x.log'}\n" +
-                            "  writeFile file: 'x.log', text: 'third message'\n" +
-                            "  echo(/got: ${readFile('x.log').trim().replaceAll('\\\\s+', ' ')}/)\n" +
-                            "}", true));
+                    """
+                            node('remote') {
+                              tee('x.log') {
+                                if (isUnix()) { sh 'echo first message' } else { bat 'echo first message' }
+                                semaphore 'wait'
+                                if (isUnix()) { sh 'echo second message' } else { bat 'echo second message' }
+                              }
+                              if (isUnix()) {sh 'rm x.log'} else {bat 'del x.log'}
+                              writeFile file: 'x.log', text: 'third message'
+                              echo(/got: ${readFile('x.log').trim().replaceAll('\\\\s+', ' ')}/)
+                            }""",
+                    true));
             WorkflowRun b = p.scheduleBuild2(0).waitForStart();
             SemaphoreStep.waitForStart("wait/1", b);
         });
@@ -136,10 +145,9 @@ public class TeeStepTest {
     @Test
     public void configRoundtrip() throws Throwable {
         sessions.then(r -> {
-                TeeStep s = new TeeStep("x.log");
-                StepConfigTester t = new StepConfigTester(r);
-                r.assertEqualDataBoundBeans(s, t.configRoundTrip(s));
+            TeeStep s = new TeeStep("x.log");
+            StepConfigTester t = new StepConfigTester(r);
+            r.assertEqualDataBoundBeans(s, t.configRoundTrip(s));
         });
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/json/ReadJSONStepTest.java
@@ -24,6 +24,11 @@
 
 package org.jenkinsci.plugins.pipeline.utility.steps.json;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.jenkinsci.plugins.pipeline.utility.steps.Messages.AbstractFileOrTextStepDescriptorImpl_missingRequiredArgument;
+
 import hudson.model.Result;
 import java.io.File;
 import java.io.FileWriter;
@@ -34,99 +39,107 @@ import java.io.Writer;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.IOUtils;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.not;
 import org.jenkinsci.plugins.pipeline.utility.steps.FilenameTestsUtils;
-import static org.jenkinsci.plugins.pipeline.utility.steps.Messages.AbstractFileOrTextStepDescriptorImpl_missingRequiredArgument;
 import org.jenkinsci.plugins.workflow.actions.ArgumentsAction;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.graphanalysis.DepthFirstScanner;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 /**
  * Tests for {@link ReadJSONStep}.
  *
  * @author Nikolas Falco
  */
-public class ReadJSONStepTest {
+@WithJenkins
+class ReadJSONStepTest {
     private static final String SOME_JSON = "{\"aNullValue\": null,\"tags\": [0, 1, 2, null]}";
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+    private JenkinsRule j;
 
-    @Rule
-    public TemporaryFolder temp = new TemporaryFolder();
+    @TempDir
+    private File temp;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) {
+        j = rule;
+    }
 
     @Test
-    public void readFile() throws Exception {
+    void readFile() throws Exception {
         String file = writeJSON(getJSON());
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                        "  def json = readJSON file: '" + file + "'\n" +
-                        "  assert json.isArray() == false\n" +
-                        "  assert json.tags.isArray() == true\n" +
-                        "  assert json.tags.size() == 3\n" +
-                        "  assert json.tags[0] == 0\n" +
-                        "  assert json.tags[1] == 1\n" +
-                        "  assert json.tags[2] == 2\n" +
-                        "}", true));
+                "node {\n" + "  def json = readJSON file: '"
+                        + file + "'\n" + "  assert json.isArray() == false\n"
+                        + "  assert json.tags.isArray() == true\n"
+                        + "  assert json.tags.size() == 3\n"
+                        + "  assert json.tags[0] == 0\n"
+                        + "  assert json.tags[1] == 1\n"
+                        + "  assert json.tags[2] == 2\n"
+                        + "}",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void readText() throws Exception {
+    void readText() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "def json = readJSON text: '" + getJSON() + "'\n" +
-                        "assert json.tags[0] == 0\n" +
-                        "assert json.tags[1] == 1\n" +
-                        "assert json.tags[2] == 2\n", true));
+                "def json = readJSON text: '" + getJSON() + "'\n" + "assert json.tags[0] == 0\n"
+                        + "assert json.tags[1] == 1\n"
+                        + "assert json.tags[2] == 2\n",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void readDirectText() throws Exception {
+    void readDirectText() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "def json = readJSON text: '[ { \"key\": 0 }, { \"key\": \"value\" }, { \"key\": true } ]'\n" +
-                        "assert json.isArray() == true\n" +
-                        "assert json.size() == 3\n" +
-                        "assert json[0].key == 0\n" +
-                        "assert json[1].key == 'value'\n" +
-                        "assert json[2].key == true\n", true));
+                """
+                        def json = readJSON text: '[ { "key": 0 }, { "key": "value" }, { "key": true } ]'
+                        assert json.isArray() == true
+                        assert json.size() == 3
+                        assert json[0].key == 0
+                        assert json[1].key == 'value'
+                        assert json[2].key == true
+                        """,
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void readNone() throws Exception {
+    void readNone() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                        "  def json = readJSON()\n" +
-                        "}", true));
-        WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+                """
+                        node {
+                          def json = readJSON()
+                        }""",
+                true));
+        WorkflowRun run =
+                j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
         j.assertLogContains(AbstractFileOrTextStepDescriptorImpl_missingRequiredArgument("readJSON"), run);
     }
 
     @Test
-    public void readFileAndText() throws Exception {
+    void readFileAndText() throws Exception {
         String file = writeJSON(getJSON());
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                        "  def json = readJSON( text: '{ \"key\": \"value\" }', file: '" + file + "' )\n" +
-                        "}", true));
-        WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+                "node {\n" + "  def json = readJSON( text: '{ \"key\": \"value\" }', file: '" + file + "' )\n" + "}",
+                true));
+        WorkflowRun run =
+                j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
         j.assertLogContains(Messages.ReadJSONStepExecution_tooManyArguments("readJSON"), run);
     }
 
@@ -141,96 +154,106 @@ public class ReadJSONStepTest {
     }
 
     private String writeJSON(String json) throws IOException {
-        File file = temp.newFile();
-        try (Writer f = new FileWriter(file); Reader r = new StringReader(json)) {
+        File file = File.createTempFile("junit", null, temp);
+        try (Writer f = new FileWriter(file);
+                Reader r = new StringReader(json)) {
             IOUtils.copy(r, f);
         }
         return FilenameTestsUtils.toPath(file);
     }
 
-
     @Test
-    public void readFileAsPojo() throws Exception {
+    void readFileAsPojo() throws Exception {
         String file = writeJSON(SOME_JSON);
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                        "  def json = readJSON file: '" + file + "', returnPojo: true\n" +
-                        "  assert json.subMap([]).isEmpty()\n" +
-                        "  assert json.aNullValue == null\n" +
-                        "  assert json.tags.size() == 4\n" +
-                        "  assert json.tags.unique().size() == 4\n" +
-                        "  assert json.tags[0] == 0\n" +
-                        "  assert json.tags[1] == 1\n" +
-                        "  assert json.tags[2] == 2\n" +
-                        "  assert json.tags[3] == null\n" +
-                        "}", true));
+                "node {\n" + "  def json = readJSON file: '"
+                        + file + "', returnPojo: true\n" + "  assert json.subMap([]).isEmpty()\n"
+                        + "  assert json.aNullValue == null\n"
+                        + "  assert json.tags.size() == 4\n"
+                        + "  assert json.tags.unique().size() == 4\n"
+                        + "  assert json.tags[0] == 0\n"
+                        + "  assert json.tags[1] == 1\n"
+                        + "  assert json.tags[2] == 2\n"
+                        + "  assert json.tags[3] == null\n"
+                        + "}",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void readTextAsPojo() throws Exception {
+    void readTextAsPojo() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "def json = readJSON text: '" + SOME_JSON + "', returnPojo: true\n" +
-                        "assert json.subMap([]).isEmpty()\n" +
-                        "assert json.aNullValue == null\n" +
-                        "assert json.tags.size() == 4\n" +
-                        "assert json.tags.unique().size() == 4\n" +
-                        "assert json.tags[0] == 0\n" +
-                        "assert json.tags[1] == 1\n" +
-                        "assert json.tags[2] == 2\n" +
-                        "assert json.tags[3] == null\n", true));
+                "def json = readJSON text: '" + SOME_JSON + "', returnPojo: true\n"
+                        + "assert json.subMap([]).isEmpty()\n"
+                        + "assert json.aNullValue == null\n"
+                        + "assert json.tags.size() == 4\n"
+                        + "assert json.tags.unique().size() == 4\n"
+                        + "assert json.tags[0] == 0\n"
+                        + "assert json.tags[1] == 1\n"
+                        + "assert json.tags[2] == 2\n"
+                        + "assert json.tags[3] == null\n",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void readDirectTextAsPojo() throws Exception {
+    void readDirectTextAsPojo() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "def json = readJSON text: '[ { \"key\": 0 }, { \"key\": \"value\" }, { \"key\": true }, { \"key\": null } ]', returnPojo: true\n" +
-                        "assert json.size() == 4\n" +
-                        "assert json.unique().size() == 4\n" +
-                        "assert json[0].key == 0\n" +
-                        "assert json[1].key == 'value'\n" +
-                        "assert json[2].key == true\n" +
-                        "assert json[3].key == null\n", true));
+                """
+                        def json = readJSON text: '[ { "key": 0 }, { "key": "value" }, { "key": true }, { "key": null } ]', returnPojo: true
+                        assert json.size() == 4
+                        assert json.unique().size() == 4
+                        assert json[0].key == 0
+                        assert json[1].key == 'value'
+                        assert json[2].key == true
+                        assert json[3].key == null
+                        """,
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void readNoneAsPojo() throws Exception {
+    void readNoneAsPojo() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                        "  def json = readJSON(returnPojo: true)\n" +
-                        "}", true));
-        WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+                """
+                        node {
+                          def json = readJSON(returnPojo: true)
+                        }""",
+                true));
+        WorkflowRun run =
+                j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
         j.assertLogContains(AbstractFileOrTextStepDescriptorImpl_missingRequiredArgument("readJSON"), run);
     }
 
     @Test
-    public void readFileAndTextAsPojo() throws Exception {
+    void readFileAndTextAsPojo() throws Exception {
         String file = writeJSON(SOME_JSON);
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                        "  def json = readJSON( text: '{ \"key\": \"value\" }', file: '" + file + "', returnPojo: true )\n" +
-                        "}", true));
-        WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+                "node {\n" + "  def json = readJSON( text: '{ \"key\": \"value\" }', file: '" + file
+                        + "', returnPojo: true )\n" + "}",
+                true));
+        WorkflowRun run =
+                j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
         j.assertLogContains(Messages.ReadJSONStepExecution_tooManyArguments("readJSON"), run);
     }
 
     @Test
-    public void readTextHideContents() throws Exception {
+    void readTextHideContents() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("readJSON text: '{\"val\":\"s3cr3t\"}'", true));
         WorkflowRun b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         for (FlowNode n : new DepthFirstScanner().allNodes(b.getExecution())) {
-            assertThat("did not leak secret in " + n + " ~ " + n.getDisplayName(), ArgumentsAction.getStepArgumentsAsString(n), not(containsString("s3cr3t")));
+            assertThat(
+                    "did not leak secret in " + n + " ~ " + n.getDisplayName(),
+                    ArgumentsAction.getStepArgumentsAsString(n),
+                    not(containsString("s3cr3t")));
         }
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/json/WriteJSONStepTest.java
@@ -29,89 +29,90 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-
-import java.io.File;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-
-import org.jenkinsci.plugins.pipeline.utility.steps.FilenameTestsUtils;
-import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
-import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.jvnet.hudson.test.JenkinsRule;
+import static org.junit.jupiter.api.Assertions.*;
 
 import hudson.model.Result;
-
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import net.sf.json.JSON;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import net.sf.json.JSONSerializer;
+import org.jenkinsci.plugins.pipeline.utility.steps.FilenameTestsUtils;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 /**
  * Tests for {@link WriteJSONStep}.
  *
  * @author Nikolas Falco
  */
-public class WriteJSONStepTest {
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
-    @Rule
-    public TemporaryFolder temp = new TemporaryFolder();
+@WithJenkins
+class WriteJSONStepTest {
 
-    @Test
-    public void writeFilePretty() throws Exception {
-        File output = temp.newFile();
+    private JenkinsRule j;
 
-        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                        " def json = readJSON text: '{\"a\": {\"1\": true,\"2\": 2}}' \n" +
-                        " writeJSON file: '" + FilenameTestsUtils.toPath(output) + "', json: json, pretty: 4\n" +
-                        "}", true));
-        j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    @TempDir
+    private File temp;
 
-        String lines = new String(Files.readAllBytes(Paths.get(output.toURI())), StandardCharsets.UTF_8);
-        assertThat(lines.split("\r\n|\r|\n").length, equalTo(4));
-
+    @BeforeEach
+    void setUp(JenkinsRule rule) {
+        j = rule;
     }
 
     @Test
-    public void writeFilePrettyEmpty() throws Exception {
-        File output = temp.newFile();
+    void writeFilePretty() throws Exception {
+        File output = File.createTempFile("junit", null, temp);
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                        " def json = readJSON text: '{}' \n" +
-                        " writeJSON file: '" + FilenameTestsUtils.toPath(output) + "', json: json, pretty: 4\n" +
-                        "}", true));
+                "node {\n" + " def json = readJSON text: '{\"a\": {\"1\": true,\"2\": 2}}' \n"
+                        + " writeJSON file: '"
+                        + FilenameTestsUtils.toPath(output) + "', json: json, pretty: 4\n" + "}",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
 
-        String lines = new String(Files.readAllBytes(Paths.get(output.toURI())), StandardCharsets.UTF_8);
+        String lines = Files.readString(Paths.get(output.toURI()));
+        assertThat(lines.split("\r\n|\r|\n").length, equalTo(4));
+    }
+
+    @Test
+    void writeFilePrettyEmpty() throws Exception {
+        File output = File.createTempFile("junit", null, temp);
+
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node {\n" + " def json = readJSON text: '{}' \n"
+                        + " writeJSON file: '"
+                        + FilenameTestsUtils.toPath(output) + "', json: json, pretty: 4\n" + "}",
+                true));
+        j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+
+        String lines = Files.readString(Paths.get(output.toURI()));
         assertThat(lines.split("\r\n|\r|\n").length, equalTo(1));
     }
 
     @Test
-    public void writeFile() throws Exception {
+    void writeFile() throws Exception {
         int elements = 3;
         String input = getJSON(elements);
-        File output = temp.newFile();
+        File output = File.createTempFile("junit", null, temp);
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                        "  def json = readJSON text: '" + input + "'\n" +
-                        "  json[0] = null\n" +
-                        "  json[" + elements + "] = 45\n" +
-                        "  writeJSON file: '" + FilenameTestsUtils.toPath(output) + "', json: json\n" +
-                        "}", true));
+                "node {\n" + "  def json = readJSON text: '"
+                        + input + "'\n" + "  json[0] = null\n"
+                        + "  json["
+                        + elements + "] = 45\n" + "  writeJSON file: '"
+                        + FilenameTestsUtils.toPath(output) + "', json: json\n" + "}",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
 
         // file exists by default so we check that should not be empty
@@ -122,67 +123,70 @@ public class WriteJSONStepTest {
         assertThat(json, instanceOf(JSONArray.class));
 
         JSONArray jsonArray = (JSONArray) json;
-        assertFalse("Saved json is an empty array", jsonArray.isEmpty());
+        assertFalse(jsonArray.isEmpty(), "Saved json is an empty array");
         assertThat(jsonArray.size(), is(elements + 1));
-        assertNotNull("Unexpected element value", jsonArray.get(0));
-        assertEquals("Unexpected element value", 45, jsonArray.get(elements));
+        assertNotNull(jsonArray.get(0), "Unexpected element value");
+        assertEquals(45, jsonArray.get(elements), "Unexpected element value");
     }
 
     @Test
-    public void returnText() throws Exception {
+    void returnText() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                        "  String written = writeJSON returnText: true, json: ['a': 1, 'b': 2] \n" +
-                        "  def json = readJSON text: written, returnPojo: true \n" +
-                        "  assert json == ['a': 1, 'b': 2] \n" +
-                        "}",
+                """
+                        node {
+                          String written = writeJSON returnText: true, json: ['a': 1, 'b': 2]
+                          def json = readJSON text: written, returnPojo: true
+                          assert json == ['a': 1, 'b': 2]
+                        }""",
                 true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void returnTextWithoutNode() throws Exception {
+    void returnTextWithoutNode() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "String written = writeJSON returnText: true, json: ['a': 1, 'b': 2] \n" +
-                "def json = readJSON text: written, returnPojo: true \n" +
-                "assert json == ['a': 1, 'b': 2] \n",
+                """
+                        String written = writeJSON returnText: true, json: ['a': 1, 'b': 2]
+                        def json = readJSON text: written, returnPojo: true
+                        assert json == ['a': 1, 'b': 2]
+                        """,
                 true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void checkRequiredFileOrReturnText() throws Exception {
+    void checkRequiredFileOrReturnText() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                        "  def json = readJSON text: '{}'\n" +
-                        "  writeJSON json: json" +
-                        "}", true));
-        WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+                """
+                        node {
+                          def json = readJSON text: '{}'
+                          writeJSON json: json\
+                        }""",
+                true));
+        WorkflowRun run =
+                j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
         j.assertLogContains(Messages.WriteJSONStepExecution_missingReturnTextAndFile("writeJSON"), run);
     }
 
     @Test
-    public void checkRequiredJSON() throws Exception {
+    void checkRequiredJSON() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                        "  writeJSON file: 'output.json'" +
-                        "}", true));
-        WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+        p.setDefinition(new CpsFlowDefinition("node {\n" + "  writeJSON file: 'output.json'" + "}", true));
+        WorkflowRun run =
+                j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
         j.assertLogContains(Messages.WriteJSONStepExecution_missingJSON("writeJSON"), run);
     }
 
     @Test
-    public void checkCannotReturnTextAndFile() throws Exception {
+    void checkCannotReturnTextAndFile() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                        "  writeJSON returnText:true, file: 'output.json', json: [foo: 'bar']" +
-                        "}", true));
-        WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+                "node {\n" + "  writeJSON returnText:true, file: 'output.json', json: [foo: 'bar']" + "}", true));
+        WorkflowRun run =
+                j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
         j.assertLogContains(Messages.WriteJSONStepExecution_bothReturnTextAndFile("writeJSON"), run);
     }
 
@@ -195,5 +199,4 @@ public class WriteJSONStepTest {
         }
         return root.toString();
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/tar/UnTarStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/tar/UnTarStepTest.java
@@ -24,49 +24,46 @@
 
 package org.jenkinsci.plugins.pipeline.utility.steps.tar;
 
+import static org.jenkinsci.plugins.pipeline.utility.steps.FilenameTestsUtils.separatorsToSystemEscaped;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import hudson.model.Label;
 import hudson.model.Result;
+import java.io.File;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import org.jenkinsci.plugins.pipeline.utility.steps.DecompressStepExecution;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.jvnet.hudson.test.BuildWatcher;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import java.io.File;
-import java.net.URL;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-
-import static org.jenkinsci.plugins.pipeline.utility.steps.FilenameTestsUtils.separatorsToSystemEscaped;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assume.assumeTrue;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 /**
  * Tests for {@link UnTarStep}.
  *
  * @author Alexander Falkenstern &lt;Alexander.Falkenstern@gmail.com&gt;.
  */
-public class UnTarStepTest {
+@WithJenkins
+class UnTarStepTest {
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
-    @Rule
-    public BuildWatcher watcher = new BuildWatcher();
+    private JenkinsRule j;
 
-    @Before
-    public void setup() throws Exception {
+    @BeforeEach
+    void setUp(JenkinsRule rule) throws Exception {
+        j = rule;
         j.createOnlineSlave(Label.get("slaves"));
     }
 
     @Test
-    public void configRoundTrip() throws Exception {
+    void configRoundTrip() throws Exception {
         UnTarStep step = new UnTarStep("target/my.tgz");
         step.setDir("base/");
         step.setGlob("**/*.tgz");
@@ -78,24 +75,26 @@ public class UnTarStepTest {
     }
 
     @Test
-    public void simpleUntar() throws Exception {
+    void simpleUntar() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  dir('compressIt') {\n" +
-                        "    writeFile file: 'hello.txt', text: 'Hello World!'\n" +
-                        "    writeFile file: 'hello.dat', text: 'Hello World!'\n" +
-                        "    dir('two') {\n" +
-                        "      writeFile file: 'hello.txt', text: 'Hello World2!'\n" +
-                        "    }\n" +
-                        "    tar file: '../hello.tgz'\n" +
-                        "  }\n" +
-                        "  dir('decompressIt') {\n" +
-                        "    untar '../hello.tgz'\n" +
-                        "    String txt = readFile 'hello.txt'\n" +
-                        "    echo \"Reading: ${txt}\"\n" +
-                        "  }\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          dir('compressIt') {
+                            writeFile file: 'hello.txt', text: 'Hello World!'
+                            writeFile file: 'hello.dat', text: 'Hello World!'
+                            dir('two') {
+                              writeFile file: 'hello.txt', text: 'Hello World2!'
+                            }
+                            tar file: '../hello.tgz'
+                          }
+                          dir('decompressIt') {
+                            untar '../hello.tgz'
+                            String txt = readFile 'hello.txt'
+                            echo "Reading: ${txt}"
+                          }
+                        }""",
+                true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         j.assertLogContains("Extracting: hello.txt ->", run);
         j.assertLogContains("Extracting: two/hello.txt ->", run);
@@ -104,26 +103,28 @@ public class UnTarStepTest {
     }
 
     @Test
-    public void globUntar() throws Exception {
+    void globUntar() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  dir('compressIt') {\n" +
-                        "    writeFile file: 'hello.txt', text: 'Hello World!'\n" +
-                        "    writeFile file: 'hello.dat', text: 'Hello World!'\n" +
-                        "    dir('two') {\n" +
-                        "      writeFile file: 'hello.txt', text: 'Hello World2!'\n" +
-                        "    }\n" +
-                        "    tar file: '../hello.tar.gz'\n" +
-                        "  }\n" +
-                        "  dir('decompressIt') {\n" +
-                        "    untar file: '../hello.tar.gz', glob: '**/*.txt'\n" +
-                        "    String txt = readFile 'hello.txt'\n" +
-                        "    echo \"Reading: ${txt}\"\n" +
-                        "    txt = readFile 'two/hello.txt'\n" +
-                        "    echo \"Reading: ${txt}\"\n" +
-                        "  }\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          dir('compressIt') {
+                            writeFile file: 'hello.txt', text: 'Hello World!'
+                            writeFile file: 'hello.dat', text: 'Hello World!'
+                            dir('two') {
+                              writeFile file: 'hello.txt', text: 'Hello World2!'
+                            }
+                            tar file: '../hello.tar.gz'
+                          }
+                          dir('decompressIt') {
+                            untar file: '../hello.tar.gz', glob: '**/*.txt'
+                            String txt = readFile 'hello.txt'
+                            echo "Reading: ${txt}"
+                            txt = readFile 'two/hello.txt'
+                            echo "Reading: ${txt}"
+                          }
+                        }""",
+                true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         j.assertLogContains("Extracting: hello.txt ->", run);
         j.assertLogContains("Extracting: two/hello.txt ->", run);
@@ -133,120 +134,132 @@ public class UnTarStepTest {
     }
 
     @Test
-    public void tarTest() throws Exception {
-        Assume.assumeTrue("Can only run in a gnu unix environment", File.pathSeparatorChar == ':');
+    void tarTest() throws Exception {
+        Assumptions.assumeTrue(File.pathSeparatorChar == ':', "Can only run in a gnu unix environment");
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  dir('compressIt') {\n" +
-                        "    writeFile file: 'hello.txt', text: 'Hello World!'\n" +
-                        "    writeFile file: 'hello.dat', text: 'Hello Data World!'\n" +
-                        "    dir('two') {\n" +
-                        "      writeFile file: 'hello.txt', text: 'Hello World2!'\n" +
-                        "    }\n" +
-                        "    tar file: '../hello.tgz'\n" +
-                        "  }\n" +
-                        "  sh 'head -c $(($(cat hello.tgz | wc -c) / 2)) hello.tgz > corrupt.tgz'\n" +
-                        "  def result = untar file: 'corrupt.tgz', test: true \n" +
-                        "  if (result != false)\n" +
-                        "      error('Should be corrupt!')\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          dir('compressIt') {
+                            writeFile file: 'hello.txt', text: 'Hello World!'
+                            writeFile file: 'hello.dat', text: 'Hello Data World!'
+                            dir('two') {
+                              writeFile file: 'hello.txt', text: 'Hello World2!'
+                            }
+                            tar file: '../hello.tgz'
+                          }
+                          sh 'head -c $(($(cat hello.tgz | wc -c) / 2)) hello.tgz > corrupt.tgz'
+                          def result = untar file: 'corrupt.tgz', test: true
+                          if (result != false)
+                              error('Should be corrupt!')
+                        }""",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void testTarGZTestingBrokenTarGZ() throws Exception {
+    void testTarGZTestingBrokenTarGZ() throws Exception {
         /*
-         This test uses a prepared tgz file that has a single flipped bit inside the byte stream of the tgz file entry.
-         The test method has to find this error. This will require the stream to be read, because the CRC check is able
-         to reveal this error.
-         */
+        This test uses a prepared tgz file that has a single flipped bit inside the byte stream of the tgz file entry.
+        The test method has to find this error. This will require the stream to be read, because the CRC check is able
+        to reveal this error.
+        */
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         URL resource = getClass().getResource("test_broken.tar.gz");
-        String tgz = new File(URLDecoder.decode(resource.getPath(), "UTF-8")).getAbsolutePath().replace('\\', '/');
+        String tgz = new File(URLDecoder.decode(resource.getPath(), StandardCharsets.UTF_8))
+                .getAbsolutePath()
+                .replace('\\', '/');
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                "  def result = untar file: '" + separatorsToSystemEscaped(tgz) + "', test: true\n" +
-                "  if (result)\n" +
-                "      error('Should be corrupt!')\n" +
-                "}", true));
+                "node {\n" + "  def result = untar file: '"
+                        + separatorsToSystemEscaped(tgz) + "', test: true\n" + "  if (result)\n"
+                        + "      error('Should be corrupt!')\n"
+                        + "}",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void testTarGZTestingOkayTarGZ() throws Exception {
+    void testTarGZTestingOkayTarGZ() throws Exception {
         /*
-         This test uses a prepared tar.gz file without any errors.
-         */
+        This test uses a prepared tar.gz file without any errors.
+        */
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         URL resource = getClass().getResource("test_ok.tar.gz");
-        String tgz = new File(URLDecoder.decode(resource.getPath(), "UTF-8")).getAbsolutePath().replace('\\', '/');
+        String tgz = new File(URLDecoder.decode(resource.getPath(), StandardCharsets.UTF_8))
+                .getAbsolutePath()
+                .replace('\\', '/');
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                "  def result = untar file: '" + separatorsToSystemEscaped(tgz) + "', test: true\n" +
-                "  if (!result)\n" +
-                "      error('Should be okay!')\n" +
-                "}", true));
+                "node {\n" + "  def result = untar file: '"
+                        + separatorsToSystemEscaped(tgz) + "', test: true\n" + "  if (!result)\n"
+                        + "      error('Should be okay!')\n"
+                        + "}",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void testTarTestingBrokenTar() throws Exception {
+    void testTarTestingBrokenTar() throws Exception {
         /*
-         This test uses a prepared tgz file that has a single flipped bit inside the byte stream of the tgz file entry.
-         The test method has to find this error. This will require the stream to be read, because the CRC check is able
-         to reveal this error.
-         */
+        This test uses a prepared tgz file that has a single flipped bit inside the byte stream of the tgz file entry.
+        The test method has to find this error. This will require the stream to be read, because the CRC check is able
+        to reveal this error.
+        */
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         URL resource = getClass().getResource("test_broken.tar");
-        String tgz = new File(URLDecoder.decode(resource.getPath(), "UTF-8")).getAbsolutePath().replace('\\', '/');
+        String tgz = new File(URLDecoder.decode(resource.getPath(), StandardCharsets.UTF_8))
+                .getAbsolutePath()
+                .replace('\\', '/');
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                        "  def result = untar file: '" + separatorsToSystemEscaped(tgz) + "', test: true\n" +
-                        "  if (result)\n" +
-                        "      error('Should be corrupt!')\n" +
-                        "}", true));
+                "node {\n" + "  def result = untar file: '"
+                        + separatorsToSystemEscaped(tgz) + "', test: true\n" + "  if (result)\n"
+                        + "      error('Should be corrupt!')\n"
+                        + "}",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void testTarTestingOkayTar() throws Exception {
+    void testTarTestingOkayTar() throws Exception {
         /*
-         This test uses a prepared tar.gz file without any errors.
-         */
+        This test uses a prepared tar.gz file without any errors.
+        */
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         URL resource = getClass().getResource("test_ok.tar");
-        String tgz = new File(URLDecoder.decode(resource.getPath(), "UTF-8")).getAbsolutePath().replace('\\', '/');
+        String tgz = new File(URLDecoder.decode(resource.getPath(), StandardCharsets.UTF_8))
+                .getAbsolutePath()
+                .replace('\\', '/');
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                        "  def result = untar file: '" + separatorsToSystemEscaped(tgz) + "', test: true\n" +
-                        "  if (!result)\n" +
-                        "      error('Should be okay!')\n" +
-                        "}", true));
+                "node {\n" + "  def result = untar file: '"
+                        + separatorsToSystemEscaped(tgz) + "', test: true\n" + "  if (!result)\n"
+                        + "      error('Should be okay!')\n"
+                        + "}",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void untarQuiet() throws Exception {
+    void untarQuiet() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  dir('compressIt') {\n" +
-                        "    writeFile file: 'hello.txt', text: 'Hello World!'\n" +
-                        "    writeFile file: 'hello.dat', text: 'Hello World!'\n" +
-                        "    dir('two') {\n" +
-                        "      writeFile file: 'hello.txt', text: 'Hello World2!'\n" +
-                        "    }\n" +
-                        "    tar file: '../hello.tgz'\n" +
-                        "  }\n" +
-                        "  dir('decompressIt') {\n" +
-                        "    untar file: '../hello.tgz', quiet: true\n" +
-                        "    String txt = readFile 'hello.txt'\n" +
-                        "    echo \"Reading: ${txt}\"\n" +
-                        "    txt = readFile 'two/hello.txt'\n" +
-                        "    echo \"Reading: ${txt}\"\n" +
-                        "  }\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          dir('compressIt') {
+                            writeFile file: 'hello.txt', text: 'Hello World!'
+                            writeFile file: 'hello.dat', text: 'Hello World!'
+                            dir('two') {
+                              writeFile file: 'hello.txt', text: 'Hello World2!'
+                            }
+                            tar file: '../hello.tgz'
+                          }
+                          dir('decompressIt') {
+                            untar file: '../hello.tgz', quiet: true
+                            String txt = readFile 'hello.txt'
+                            echo "Reading: ${txt}"
+                            txt = readFile 'two/hello.txt'
+                            echo "Reading: ${txt}"
+                          }
+                        }""",
+                true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         j.assertLogNotContains("Extracting: hello.txt ->", run);
         j.assertLogNotContains("Extracting: two/hello.txt ->", run);
@@ -255,64 +268,73 @@ public class UnTarStepTest {
         j.assertLogContains("Reading: Hello World!", run);
         j.assertLogContains("Reading: Hello World2!", run);
     }
+
     @Test
-    public void untarKeepPermissions() throws Exception {
+    void untarKeepPermissions() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  dir('compressIt') {\n" +
-                        "    writeFile file: 'hello.txt', text: 'Hello World!'\n" +
-                        "    if (isUnix()) {\n" +
-                        "      sh 'chmod +x ./hello.txt'\n" +
-                        "    }\n" +
-                        "    tar file: '../hello.tgz'\n" +
-                        "  }\n" +
-                        "  dir('decompressIt') {\n" +
-                        "    untar file: '../hello.tgz', quiet: true\n" +
-                        "    String txt = ''\n" +
-                        "    if (isUnix()) {\n" +
-                        "      txt = sh(script: 'if [ -x ./hello.txt ]; then cat ./hello.txt; else echo false; fi', returnStdout: true).trim()\n" +
-                        "    } else {\n" +
-                        "      txt = readFile 'hello.txt'\n" +
-                        "    }\n" +
-                        "    echo \"${txt}\"" +
-                        "  }\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          dir('compressIt') {
+                            writeFile file: 'hello.txt', text: 'Hello World!'
+                            if (isUnix()) {
+                              sh 'chmod +x ./hello.txt'
+                            }
+                            tar file: '../hello.tgz'
+                          }
+                          dir('decompressIt') {
+                            untar file: '../hello.tgz', quiet: true
+                            String txt = ''
+                            if (isUnix()) {
+                              txt = sh(script: 'if [ -x ./hello.txt ]; then cat ./hello.txt; else echo false; fi', returnStdout: true).trim()
+                            } else {
+                              txt = readFile 'hello.txt'
+                            }
+                            echo "${txt}"\
+                          }
+                        }""",
+                true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         j.assertLogContains("Hello World!", run);
     }
 
-    @Test @Issue("SECURITY-2196")
-    public void testingAbsolutePathsShouldFail() throws Exception {
-        assumeTrue("Can only run in a gnu unix environment", File.pathSeparatorChar == ':');
+    @Test
+    @Issue("SECURITY-2196")
+    void testingAbsolutePathsShouldFail() throws Exception {
+        assumeTrue(File.pathSeparatorChar == ':', "Can only run in a gnu unix environment");
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         URL resource = getClass().getResource("absolute.tar");
-        String tgz = new File(URLDecoder.decode(resource.getPath(), StandardCharsets.UTF_8)).getAbsolutePath().replace('\\', '/');
+        String tgz = new File(URLDecoder.decode(resource.getPath(), StandardCharsets.UTF_8))
+                .getAbsolutePath()
+                .replace('\\', '/');
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                        "  def result = untar file: '" + separatorsToSystemEscaped(tgz) + "', test: true\n" +
-                        "  if (result)\n" +
-                        "      error('Should be fail!')\n" +
-                        "}", true));
+                "node {\n" + "  def result = untar file: '"
+                        + separatorsToSystemEscaped(tgz) + "', test: true\n" + "  if (result)\n"
+                        + "      error('Should be fail!')\n"
+                        + "}",
+                true));
         WorkflowRun run = j.buildAndAssertSuccess(p);
         j.assertLogContains("is out of bounds!", run);
     }
 
-    @Test @Issue("SECURITY-2196")
-    public void testingAbsolutePathsShouldNotFailWithEscapeHatch() throws Exception {
-        assumeTrue("Can only run in a gnu unix environment", File.pathSeparatorChar == ':');
+    @Test
+    @Issue("SECURITY-2196")
+    void testingAbsolutePathsShouldNotFailWithEscapeHatch() throws Exception {
+        assumeTrue(File.pathSeparatorChar == ':', "Can only run in a gnu unix environment");
         try {
             DecompressStepExecution.ALLOW_EXTRACTION_OUTSIDE_DESTINATION = true;
             j.createOnlineSlave(Label.get("bbb"));
             WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
             URL resource = getClass().getResource("absolute.tar");
-            String tgz = new File(URLDecoder.decode(resource.getPath(), StandardCharsets.UTF_8)).getAbsolutePath().replace('\\', '/');
+            String tgz = new File(URLDecoder.decode(resource.getPath(), StandardCharsets.UTF_8))
+                    .getAbsolutePath()
+                    .replace('\\', '/');
             p.setDefinition(new CpsFlowDefinition(
-                    "node('bbb') {\n" +
-                            "  def result = untar file: '" + separatorsToSystemEscaped(tgz) + "', test: true\n" +
-                            "  if (!result)\n" +
-                            "      error('Should not be fail!')\n" +
-                            "}", true));
+                    "node('bbb') {\n" + "  def result = untar file: '"
+                            + separatorsToSystemEscaped(tgz) + "', test: true\n" + "  if (!result)\n"
+                            + "      error('Should not be fail!')\n"
+                            + "}",
+                    true));
             WorkflowRun run = j.buildAndAssertSuccess(p);
             j.assertLogNotContains("is out of bounds!", run);
         } finally {
@@ -320,34 +342,35 @@ public class UnTarStepTest {
         }
     }
 
-    @Test @Issue("SECURITY-2196")
-    public void absolutePathsShouldFailBuild() throws Exception {
-        assumeTrue("Can only run in a gnu unix environment", File.pathSeparatorChar == ':');
+    @Test
+    @Issue("SECURITY-2196")
+    void absolutePathsShouldFailBuild() throws Exception {
+        assumeTrue(File.pathSeparatorChar == ':', "Can only run in a gnu unix environment");
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         URL resource = getClass().getResource("absolute.tar");
-        String tgz = new File(URLDecoder.decode(resource.getPath(), StandardCharsets.UTF_8)).getAbsolutePath().replace('\\', '/');
+        String tgz = new File(URLDecoder.decode(resource.getPath(), StandardCharsets.UTF_8))
+                .getAbsolutePath()
+                .replace('\\', '/');
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                        "  untar file: '" + separatorsToSystemEscaped(tgz) + "'\n" +
-                        "}", true));
+                "node {\n" + "  untar file: '" + separatorsToSystemEscaped(tgz) + "'\n" + "}", true));
         WorkflowRun run = j.buildAndAssertStatus(Result.FAILURE, p);
         j.assertLogContains("is out of bounds!", run);
     }
 
     @Test
     @Issue("SECURITY-2196")
-    public void absolutePathsShouldNotFailBuildWithEscapeHatch() throws Exception {
-        assumeTrue("Can only run in a gnu unix environment", File.pathSeparatorChar == ':');
+    void absolutePathsShouldNotFailBuildWithEscapeHatch() throws Exception {
+        assumeTrue(File.pathSeparatorChar == ':', "Can only run in a gnu unix environment");
         try {
             DecompressStepExecution.ALLOW_EXTRACTION_OUTSIDE_DESTINATION = true;
 
             WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
             URL resource = getClass().getResource("absolute.tar");
-            String tgz = new File(URLDecoder.decode(resource.getPath(), StandardCharsets.UTF_8)).getAbsolutePath().replace('\\', '/');
+            String tgz = new File(URLDecoder.decode(resource.getPath(), StandardCharsets.UTF_8))
+                    .getAbsolutePath()
+                    .replace('\\', '/');
             p.setDefinition(new CpsFlowDefinition(
-                    "node {\n" +
-                            "  untar file: '" + separatorsToSystemEscaped(tgz) + "'\n" +
-                            "}", true));
+                    "node {\n" + "  untar file: '" + separatorsToSystemEscaped(tgz) + "'\n" + "}", true));
             WorkflowRun run = j.buildAndAssertStatus(Result.SUCCESS, p);
             j.assertLogNotContains("is out of bounds!", run);
         } finally {

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/UnZipStepTest.java
@@ -24,48 +24,45 @@
 
 package org.jenkinsci.plugins.pipeline.utility.steps.zip;
 
-import hudson.Functions;
+import static org.jenkinsci.plugins.pipeline.utility.steps.FilenameTestsUtils.separatorsToSystemEscaped;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import hudson.model.Label;
 import hudson.model.Result;
-import hudson.model.queue.QueueTaskFuture;
+import java.io.File;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import org.jenkinsci.plugins.pipeline.utility.steps.DecompressStepExecution;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URL;
-import java.net.URLDecoder;
-
-import static org.jenkinsci.plugins.pipeline.utility.steps.FilenameTestsUtils.separatorsToSystemEscaped;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assume.assumeTrue;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 /**
  * Tests for {@link UnZipStep}.
  *
  * @author Robert Sandell &lt;rsandell@cloudbees.com&gt;.
  */
-public class UnZipStepTest {
+@WithJenkins
+class UnZipStepTest {
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+    private JenkinsRule j;
 
-    @Before
-    public void setup() throws Exception {
+    @BeforeEach
+    void setUp(JenkinsRule rule) throws Exception {
+        j = rule;
         j.createOnlineSlave(Label.get("slaves"));
     }
 
     @Test
-    public void configRoundTrip() throws Exception {
+    void configRoundTrip() throws Exception {
         UnZipStep step = new UnZipStep("target/my.zip");
         step.setDir("base/");
         step.setGlob("**/*.zip");
@@ -79,24 +76,26 @@ public class UnZipStepTest {
     }
 
     @Test
-    public void simpleUnZip() throws Exception {
+    void simpleUnZip() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  dir('zipIt') {\n" +
-                        "    writeFile file: 'hello.txt', text: 'Hello World!'\n" +
-                        "    writeFile file: 'hello.dat', text: 'Hello World!'\n" +
-                        "    dir('two') {\n" +
-                        "      writeFile file: 'hello.txt', text: 'Hello World2!'\n" +
-                        "    }\n" +
-                        "    zip zipFile: '../hello.zip'\n" +
-                        "  }\n" +
-                        "  dir('unzip') {\n" +
-                        "    unzip '../hello.zip'\n" +
-                        "    String txt = readFile 'hello.txt'\n" +
-                        "    echo \"Reading: ${txt}\"\n" +
-                        "  }\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          dir('zipIt') {
+                            writeFile file: 'hello.txt', text: 'Hello World!'
+                            writeFile file: 'hello.dat', text: 'Hello World!'
+                            dir('two') {
+                              writeFile file: 'hello.txt', text: 'Hello World2!'
+                            }
+                            zip zipFile: '../hello.zip'
+                          }
+                          dir('unzip') {
+                            unzip '../hello.zip'
+                            String txt = readFile 'hello.txt'
+                            echo "Reading: ${txt}"
+                          }
+                        }""",
+                true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         j.assertLogContains("Extracting: hello.txt ->", run);
         j.assertLogContains("Extracting: two/hello.txt ->", run);
@@ -105,26 +104,28 @@ public class UnZipStepTest {
     }
 
     @Test
-    public void globUnZip() throws Exception {
+    void globUnZip() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  dir('zipIt') {\n" +
-                        "    writeFile file: 'hello.txt', text: 'Hello World!'\n" +
-                        "    writeFile file: 'hello.dat', text: 'Hello World!'\n" +
-                        "    dir('two') {\n" +
-                        "      writeFile file: 'hello.txt', text: 'Hello World2!'\n" +
-                        "    }\n" +
-                        "    zip zipFile: '../hello.zip'\n" +
-                        "  }\n" +
-                        "  dir('unzip') {\n" +
-                        "    unzip zipFile: '../hello.zip', glob: '**/*.txt'\n" +
-                        "    String txt = readFile 'hello.txt'\n" +
-                        "    echo \"Reading: ${txt}\"\n" +
-                        "    txt = readFile 'two/hello.txt'\n" +
-                        "    echo \"Reading: ${txt}\"\n" +
-                        "  }\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          dir('zipIt') {
+                            writeFile file: 'hello.txt', text: 'Hello World!'
+                            writeFile file: 'hello.dat', text: 'Hello World!'
+                            dir('two') {
+                              writeFile file: 'hello.txt', text: 'Hello World2!'
+                            }
+                            zip zipFile: '../hello.zip'
+                          }
+                          dir('unzip') {
+                            unzip zipFile: '../hello.zip', glob: '**/*.txt'
+                            String txt = readFile 'hello.txt'
+                            echo "Reading: ${txt}"
+                            txt = readFile 'two/hello.txt'
+                            echo "Reading: ${txt}"
+                          }
+                        }""",
+                true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         j.assertLogContains("Extracting: hello.txt ->", run);
         j.assertLogContains("Extracting: two/hello.txt ->", run);
@@ -134,20 +135,22 @@ public class UnZipStepTest {
     }
 
     @Test
-    public void globReading() throws Exception {
+    void globReading() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  dir('zipIt') {\n" +
-                        "    writeFile file: 'hello.txt', text: 'Hello World!'\n" +
-                        "    writeFile file: 'hello.dat', text: 'Hello World!'\n" +
-                        "    zip zipFile: '../hello.zip'\n" +
-                        "  }\n" +
-                        "  dir('unzip') {\n" +
-                        "    def txt = unzip zipFile: '../hello.zip', glob: '**/hello.txt', read: true\n" +
-                        "    echo \"Text: ${txt.values().join('\\n')}\"\n" +
-                        "  }\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          dir('zipIt') {
+                            writeFile file: 'hello.txt', text: 'Hello World!'
+                            writeFile file: 'hello.dat', text: 'Hello World!'
+                            zip zipFile: '../hello.zip'
+                          }
+                          dir('unzip') {
+                            def txt = unzip zipFile: '../hello.zip', glob: '**/hello.txt', read: true
+                            echo "Text: ${txt.values().join('\\n')}"
+                          }
+                        }""",
+                true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         j.assertLogContains("Reading: hello.txt", run);
         j.assertLogNotContains("Reading: hello.dat", run);
@@ -155,21 +158,23 @@ public class UnZipStepTest {
     }
 
     @Test
-    public void globReadingMore() throws Exception {
+    void globReadingMore() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  dir('zipIt') {\n" +
-                        "    writeFile file: 'hello.txt', text: 'Hello World!'\n" +
-                        "    writeFile file: 'hello.dat', text: 'Hello Data World!'\n" +
-                        "  }\n" +
-                        "  zip zipFile: 'hello.zip', dir: 'zipIt'\n" +
-                        "  dir('unzip') {\n" +
-                        "    def txt = unzip zipFile: '../hello.zip', read: true\n" +
-                        "    echo \"Text: ${txt['hello.txt']}\"\n" +
-                        "    echo \"Text: ${txt['hello.dat']}\"\n" +
-                        "  }\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          dir('zipIt') {
+                            writeFile file: 'hello.txt', text: 'Hello World!'
+                            writeFile file: 'hello.dat', text: 'Hello Data World!'
+                          }
+                          zip zipFile: 'hello.zip', dir: 'zipIt'
+                          dir('unzip') {
+                            def txt = unzip zipFile: '../hello.zip', read: true
+                            echo "Text: ${txt['hello.txt']}"
+                            echo "Text: ${txt['hello.dat']}"
+                          }
+                        }""",
+                true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         j.assertLogContains("Reading: hello.txt", run);
         j.assertLogContains("Reading: hello.dat", run);
@@ -178,84 +183,92 @@ public class UnZipStepTest {
     }
 
     @Test
-    public void zipTest() throws Exception {
-        assumeTrue("Can only run in a gnu unix environment", File.pathSeparatorChar == ':');
+    void zipTest() throws Exception {
+        assumeTrue(File.pathSeparatorChar == ':', "Can only run in a gnu unix environment");
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  dir('zipIt') {\n" +
-                        "    writeFile file: 'hello.txt', text: 'Hello World!'\n" +
-                        "    writeFile file: 'hello.dat', text: 'Hello Data World!'\n" +
-                        "    dir('two') {\n" +
-                        "      writeFile file: 'hello.txt', text: 'Hello World2!'\n" +
-                        "    }\n" +
-                        "    zip zipFile: '../hello.zip'\n" +
-                        "  }\n" +
-                        "  sh 'head -c $(($(cat hello.zip | wc -c) / 2)) hello.zip > corrupt.zip'\n" +
-                        "  def result = unzip zipFile: 'corrupt.zip', test: true \n" +
-                        "  if (result != false)\n" +
-                        "      error('Should be corrupt!')\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          dir('zipIt') {
+                            writeFile file: 'hello.txt', text: 'Hello World!'
+                            writeFile file: 'hello.dat', text: 'Hello Data World!'
+                            dir('two') {
+                              writeFile file: 'hello.txt', text: 'Hello World2!'
+                            }
+                            zip zipFile: '../hello.zip'
+                          }
+                          sh 'head -c $(($(cat hello.zip | wc -c) / 2)) hello.zip > corrupt.zip'
+                          def result = unzip zipFile: 'corrupt.zip', test: true
+                          if (result != false)
+                              error('Should be corrupt!')
+                        }""",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void testZipTestingBrokenZip() throws Exception {
+    void testZipTestingBrokenZip() throws Exception {
         /*
-         This test uses a prepared zip file that has a single flipped bit inside the byte stream of the zip file entry.
-         The test method has to find this error. This will require the stream to be read, because the CRC check is able
-         to reveal this error.
-         */
+        This test uses a prepared zip file that has a single flipped bit inside the byte stream of the zip file entry.
+        The test method has to find this error. This will require the stream to be read, because the CRC check is able
+        to reveal this error.
+        */
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         URL resource = getClass().getResource("test_broken.zip");
-        String zip = new File(URLDecoder.decode(resource.getPath(), "UTF-8")).getAbsolutePath().replace('\\', '/');
+        String zip = new File(URLDecoder.decode(resource.getPath(), StandardCharsets.UTF_8))
+                .getAbsolutePath()
+                .replace('\\', '/');
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                "  def result = unzip zipFile: '" + separatorsToSystemEscaped(zip) + "', test: true\n" +
-                "  if (result)\n" +
-                "      error('Should be corrupt!')\n" +
-                "}", true));
+                "node {\n" + "  def result = unzip zipFile: '"
+                        + separatorsToSystemEscaped(zip) + "', test: true\n" + "  if (result)\n"
+                        + "      error('Should be corrupt!')\n"
+                        + "}",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void testZipTestingOkayZip() throws Exception {
+    void testZipTestingOkayZip() throws Exception {
         /*
-         This test uses a prepared zip file without any errors.
-         */
+        This test uses a prepared zip file without any errors.
+        */
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         URL resource = getClass().getResource("test_ok.zip");
-        String zip = new File(URLDecoder.decode(resource.getPath(), "UTF-8")).getAbsolutePath().replace('\\', '/');
+        String zip = new File(URLDecoder.decode(resource.getPath(), StandardCharsets.UTF_8))
+                .getAbsolutePath()
+                .replace('\\', '/');
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                "  def result = unzip zipFile: '" + separatorsToSystemEscaped(zip) + "', test: true\n" +
-                "  if (!result)\n" +
-                "      error('Should be okay!')\n" +
-                "}", true));
+                "node {\n" + "  def result = unzip zipFile: '"
+                        + separatorsToSystemEscaped(zip) + "', test: true\n" + "  if (!result)\n"
+                        + "      error('Should be okay!')\n"
+                        + "}",
+                true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test
-    public void unzipQuiet() throws Exception {
+    void unzipQuiet() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  dir('zipIt') {\n" +
-                        "    writeFile file: 'hello.txt', text: 'Hello World!'\n" +
-                        "    writeFile file: 'hello.dat', text: 'Hello World!'\n" +
-                        "    dir('two') {\n" +
-                        "      writeFile file: 'hello.txt', text: 'Hello World2!'\n" +
-                        "    }\n" +
-                        "    zip zipFile: '../hello.zip'\n" +
-                        "  }\n" +
-                        "  dir('unzip') {\n" +
-                        "    unzip zipFile: '../hello.zip', quiet: true\n" +
-                        "    String txt = readFile 'hello.txt'\n" +
-                        "    echo \"Reading: ${txt}\"\n" +
-                        "    txt = readFile 'two/hello.txt'\n" +
-                        "    echo \"Reading: ${txt}\"\n" +
-                        "  }\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          dir('zipIt') {
+                            writeFile file: 'hello.txt', text: 'Hello World!'
+                            writeFile file: 'hello.dat', text: 'Hello World!'
+                            dir('two') {
+                              writeFile file: 'hello.txt', text: 'Hello World2!'
+                            }
+                            zip zipFile: '../hello.zip'
+                          }
+                          dir('unzip') {
+                            unzip zipFile: '../hello.zip', quiet: true
+                            String txt = readFile 'hello.txt'
+                            echo "Reading: ${txt}"
+                            txt = readFile 'two/hello.txt'
+                            echo "Reading: ${txt}"
+                          }
+                        }""",
+                true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         j.assertLogNotContains("Extracting: hello.txt ->", run);
         j.assertLogNotContains("Extracting: two/hello.txt ->", run);
@@ -266,20 +279,22 @@ public class UnZipStepTest {
     }
 
     @Test
-    public void unzipQuietReading() throws Exception {
+    void unzipQuietReading() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  dir('zipIt') {\n" +
-                        "    writeFile file: 'hello.txt', text: 'Hello World!'\n" +
-                        "    writeFile file: 'hello.dat', text: 'Hello World!'\n" +
-                        "    zip zipFile: '../hello.zip'\n" +
-                        "  }\n" +
-                        "  dir('unzip') {\n" +
-                        "    def txt = unzip zipFile: '../hello.zip', quiet: true, read: true\n" +
-                        "    echo \"Text: ${txt.values().join('\\n')}\"\n" +
-                        "  }\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          dir('zipIt') {
+                            writeFile file: 'hello.txt', text: 'Hello World!'
+                            writeFile file: 'hello.dat', text: 'Hello World!'
+                            zip zipFile: '../hello.zip'
+                          }
+                          dir('unzip') {
+                            def txt = unzip zipFile: '../hello.zip', quiet: true, read: true
+                            echo "Text: ${txt.values().join('\\n')}"
+                          }
+                        }""",
+                true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         j.assertLogNotContains("Reading: hello.txt", run);
         j.assertLogNotContains("Reading: hello.dat", run);
@@ -287,43 +302,49 @@ public class UnZipStepTest {
         j.assertLogContains("Text: Hello World!", run);
     }
 
-    @Test @Issue("SECURITY-2196")
-    public void unZipMaliciousFailsTheTest() throws Exception {
-        assumeTrue("Can only run in a gnu unix environment", File.pathSeparatorChar == ':');
+    @Test
+    @Issue("SECURITY-2196")
+    void unZipMaliciousFailsTheTest() throws Exception {
+        assumeTrue(File.pathSeparatorChar == ':', "Can only run in a gnu unix environment");
         /*
-         This test uses a prepared zip file with a malicious payload.
-         */
+        This test uses a prepared zip file with a malicious payload.
+        */
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         URL resource = getClass().getResource("malicious.zip");
-        String zip = new File(URLDecoder.decode(resource.getPath(), "UTF-8")).getAbsolutePath().replace('\\', '/');
+        String zip = new File(URLDecoder.decode(resource.getPath(), StandardCharsets.UTF_8))
+                .getAbsolutePath()
+                .replace('\\', '/');
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                        "  def result = unzip zipFile: '" + separatorsToSystemEscaped(zip) + "', test: true\n" +
-                        "  if (result)\n" +
-                        "      error('Should be failed!')\n" +
-                        "}", true));
+                "node {\n" + "  def result = unzip zipFile: '"
+                        + separatorsToSystemEscaped(zip) + "', test: true\n" + "  if (result)\n"
+                        + "      error('Should be failed!')\n"
+                        + "}",
+                true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         j.assertLogContains("is out of bounds!", run);
     }
 
-    @Test @Issue("SECURITY-2196")
-    public void unZipMaliciousDoesNotFailTheTestWithEscapeHath() throws Exception {
-        assumeTrue("Can only run in a gnu unix environment", File.pathSeparatorChar == ':');
+    @Test
+    @Issue("SECURITY-2196")
+    void unZipMaliciousDoesNotFailTheTestWithEscapeHath() throws Exception {
+        assumeTrue(File.pathSeparatorChar == ':', "Can only run in a gnu unix environment");
         try {
             DecompressStepExecution.ALLOW_EXTRACTION_OUTSIDE_DESTINATION = true;
-        /*
-         This test uses a prepared zip file with a malicious payload.
-         */
+            /*
+            This test uses a prepared zip file with a malicious payload.
+            */
             j.createOnlineSlave(Label.get("bbb"));
             WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
             URL resource = getClass().getResource("malicious.zip");
-            String zip = new File(URLDecoder.decode(resource.getPath(), "UTF-8")).getAbsolutePath().replace('\\', '/');
+            String zip = new File(URLDecoder.decode(resource.getPath(), StandardCharsets.UTF_8))
+                    .getAbsolutePath()
+                    .replace('\\', '/');
             p.setDefinition(new CpsFlowDefinition(
-                    "node('bbb') {\n" +
-                            "  def result = unzip zipFile: '" + separatorsToSystemEscaped(zip) + "', test: true\n" +
-                            "  if (!result)\n" +
-                            "      error('Should not fail!')\n" +
-                            "}", true));
+                    "node('bbb') {\n" + "  def result = unzip zipFile: '"
+                            + separatorsToSystemEscaped(zip) + "', test: true\n" + "  if (!result)\n"
+                            + "      error('Should not fail!')\n"
+                            + "}",
+                    true));
             WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
             j.assertLogNotContains("is out of bounds!", run);
         } finally {
@@ -331,19 +352,20 @@ public class UnZipStepTest {
         }
     }
 
-    @Test @Issue("SECURITY-2196")
-    public void unZipMaliciousFailsTheBuild() throws Exception {
-        assumeTrue("Can only run in a gnu unix environment", File.pathSeparatorChar == ':');
+    @Test
+    @Issue("SECURITY-2196")
+    void unZipMaliciousFailsTheBuild() throws Exception {
+        assumeTrue(File.pathSeparatorChar == ':', "Can only run in a gnu unix environment");
         /*
-         This test uses a prepared zip file with a malicious payload.
-         */
+        This test uses a prepared zip file with a malicious payload.
+        */
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         URL resource = getClass().getResource("malicious.zip");
-        String zip = new File(URLDecoder.decode(resource.getPath(), "UTF-8")).getAbsolutePath().replace('\\', '/');
+        String zip = new File(URLDecoder.decode(resource.getPath(), StandardCharsets.UTF_8))
+                .getAbsolutePath()
+                .replace('\\', '/');
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                        "  unzip zipFile: '" + separatorsToSystemEscaped(zip) + "'\n" +
-                        "}", true));
+                "node {\n" + "  unzip zipFile: '" + separatorsToSystemEscaped(zip) + "'\n" + "}", true));
         WorkflowRun run = j.buildAndAssertStatus(Result.FAILURE, p);
         j.assertLogContains("is out of bounds!", run);
     }

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepTest.java
@@ -24,43 +24,44 @@
 
 package org.jenkinsci.plugins.pipeline.utility.steps.zip;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import hudson.model.Label;
 import hudson.model.Result;
 import hudson.model.Run;
+import java.io.IOException;
+import java.util.Scanner;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 import jenkins.util.VirtualFile;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import java.io.IOException;
-import java.util.Scanner;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
-
-import static org.junit.Assert.*;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 /**
  * Tests for {@link ZipStep}.
  *
  * @author Robert Sandell &lt;rsandell@cloudbees.com&gt;.
  */
-public class ZipStepTest {
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class ZipStepTest {
 
-    @Before
-    public void setup() throws Exception {
+    private JenkinsRule j;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) throws Exception {
+        j = rule;
         j.createOnlineSlave(Label.get("slaves"));
     }
 
     @Test
-    public void configRoundTrip() throws Exception {
+    void configRoundTrip() throws Exception {
         ZipStep step = new ZipStep("target/my.zip");
         step.setDir("base/");
         step.setGlob("**/*.zip");
@@ -73,33 +74,36 @@ public class ZipStepTest {
     }
 
     @Test
-    public void simpleArchivedZip() throws Exception {
+    void simpleArchivedZip() throws Exception {
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  writeFile file: 'hello.txt', text: 'Hello Outer World!'\n" +
-                        "  dir('hello') {\n" +
-                        "    writeFile file: 'hello.txt', text: 'Hello World!'\n" +
-                        "  }\n" +
-                        "  zip zipFile: 'hello.zip', dir: 'hello', archive: true\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          writeFile file: 'hello.txt', text: 'Hello Outer World!'
+                          dir('hello') {
+                            writeFile file: 'hello.txt', text: 'Hello World!'
+                          }
+                          zip zipFile: 'hello.zip', dir: 'hello', archive: true
+                        }""",
+                true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         j.assertLogContains("Compress", run);
         j.assertLogContains("Archiving", run);
         verifyArchivedHello(run, "");
-
     }
 
     @Test
-    public void shouldNotPutOutputArchiveIntoItself() throws Exception {
+    void shouldNotPutOutputArchiveIntoItself() throws Exception {
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-            "node {" +
-                "  writeFile file: 'hello.txt', text: 'Hello world'\n" +
-                "  zip zipFile: 'output.zip', dir: '', glob: '', archive: true, overwrite: true\n" +
-                "}", true));
+                """
+                        node {\
+                          writeFile file: 'hello.txt', text: 'Hello world'
+                          zip zipFile: 'output.zip', dir: '', glob: '', archive: true, overwrite: true
+                        }""",
+                true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         j.assertLogContains("Compress", run);
@@ -108,40 +112,44 @@ public class ZipStepTest {
 
     @Test
     @Issue("JENKINS-62928")
-    public void shouldNotPutOutputArchiveIntoItself_nonCanonicalPath() throws Exception {
+    void shouldNotPutOutputArchiveIntoItself_nonCanonicalPath() throws Exception {
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-            "node {" +
-                "  dir ('src') {\n" +
-                "   writeFile file: 'hello.txt', text: 'Hello world'\n" +
-                "  }\n" +
-                "  zip zipFile: 'src/../src/output.zip', dir: '', glob: '', archive: true\n" +
-                "}", true));
+                """
+                        node {\
+                          dir ('src') {
+                           writeFile file: 'hello.txt', text: 'Hello world'
+                          }
+                          zip zipFile: 'src/../src/output.zip', dir: '', glob: '', archive: true
+                        }""",
+                true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         j.assertLogContains("Compress", run);
         verifyArchivedNotContainingItself(run);
     }
 
     @Test
-    public void canArchiveFileWithSameName() throws Exception {
+    void canArchiveFileWithSameName() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node {\n" + 
-                "  dir ('src') {\n" +
-                "   writeFile file: 'hello.txt', text: 'Hello world'\n" +
-                "   writeFile file: 'output.zip', text: 'not really a zip'\n" +
-                "  }\n" +
-                "  dir ('out') {\n" +
-                "    zip zipFile: 'output.zip', dir: '../src', glob: '', archive: true, overwrite: true\n" +
-                "  }\n" +
-                "}\n",
+                """
+                        node {
+                          dir ('src') {
+                           writeFile file: 'hello.txt', text: 'Hello world'
+                           writeFile file: 'output.zip', text: 'not really a zip'
+                          }
+                          dir ('out') {
+                            zip zipFile: 'output.zip', dir: '../src', glob: '', archive: true, overwrite: true
+                          }
+                        }
+                        """,
                 true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
 
         j.assertLogContains("Compress", run);
-        assertTrue("Build should have artifacts", run.getHasArtifacts());
+        assertTrue(run.getHasArtifacts(), "Build should have artifacts");
         Run<WorkflowJob, WorkflowRun>.Artifact artifact = run.getArtifacts().get(0);
         assertEquals("output.zip", artifact.getFileName());
         VirtualFile file = run.getArtifactManager().root().child(artifact.relativePath);
@@ -151,7 +159,7 @@ public class ZipStepTest {
                 System.out.println("zip entry name is: " + entry.getName());
                 entry = zip.getNextEntry();
             }
-            assertNotNull("output.zip should be included in the zip", entry);
+            assertNotNull(entry, "output.zip should be included in the zip");
             // we should have the the zip - but double check
             assertEquals("output.zip", entry.getName());
             Scanner scanner = new Scanner(zip);
@@ -162,102 +170,113 @@ public class ZipStepTest {
     }
 
     @Test
-    public void globbedArchivedZip() throws Exception {
+    void globbedArchivedZip() throws Exception {
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  writeFile file: 'hello.outer', text: 'Hello Outer World!'\n" +
-                        "  dir('hello') {\n" +
-                        "    writeFile file: 'hello.txt', text: 'Hello World!'\n" +
-                        "  }\n" +
-                        "  zip zipFile: 'hello.zip', glob: '**/*.txt', archive: true\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          writeFile file: 'hello.outer', text: 'Hello Outer World!'
+                          dir('hello') {
+                            writeFile file: 'hello.txt', text: 'Hello World!'
+                          }
+                          zip zipFile: 'hello.zip', glob: '**/*.txt', archive: true
+                        }""",
+                true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         verifyArchivedHello(run, "hello/");
-
     }
 
     @Test
-    public void excludedPatternWithAll() throws Exception {
+    void excludedPatternWithAll() throws Exception {
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  writeFile file: 'hello.txt', text: 'Hello World!'\n" +
-                        "  writeFile file: 'goodbye.txt', text: 'Goodbye World!'\n" +
-                        "  zip zipFile: 'hello.zip', exclude: 'goodbye.txt', archive: true\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          writeFile file: 'hello.txt', text: 'Hello World!'
+                          writeFile file: 'goodbye.txt', text: 'Goodbye World!'
+                          zip zipFile: 'hello.zip', exclude: 'goodbye.txt', archive: true
+                        }""",
+                true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         verifyArchivedHello(run, "");
-
     }
 
     @Test
-    public void excludedPatternWithGlob() throws Exception {
+    void excludedPatternWithGlob() throws Exception {
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  writeFile file: 'hello.txt', text: 'Hello World!'\n" +
-                        "  writeFile file: 'goodbye.txt', text: 'Goodbye World!'\n" +
-                        "  zip zipFile: 'hello.zip', glob: '*.txt', exclude: 'goodbye.txt', archive: true\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          writeFile file: 'hello.txt', text: 'Hello World!'
+                          writeFile file: 'goodbye.txt', text: 'Goodbye World!'
+                          zip zipFile: 'hello.zip', glob: '*.txt', exclude: 'goodbye.txt', archive: true
+                        }""",
+                true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         verifyArchivedHello(run, "");
-
     }
 
     @Test
-    public void emptyZipFile() throws Exception {
+    void emptyZipFile() throws Exception {
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  zip zipFile: '', glob: '**/*.txt', archive: true\n" +
-                        "}", true));
-        WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+                """
+                        node('slaves') {
+                          zip zipFile: '', glob: '**/*.txt', archive: true
+                        }""",
+                true));
+        WorkflowRun run =
+                j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
         j.assertLogContains("Can not be empty", run);
-
     }
 
     @Test
-    public void existingZipFileWithoutOverwrite() throws Exception {
+    void existingZipFileWithoutOverwrite() throws Exception {
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  writeFile file: 'hello.zip', text: 'Hello Zip!'\n" +
-                        "  zip zipFile: 'hello.zip', glob: '**/*.txt', archive: true\n" +
-                        "}", true));
-        WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+                """
+                        node('slaves') {
+                          writeFile file: 'hello.zip', text: 'Hello Zip!'
+                          zip zipFile: 'hello.zip', glob: '**/*.txt', archive: true
+                        }""",
+                true));
+        WorkflowRun run =
+                j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
         j.assertLogContains("hello.zip exists.", run);
-
     }
 
     @Test
-    public void existingZipFileWithOverwrite() throws Exception {
+    void existingZipFileWithOverwrite() throws Exception {
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  writeFile file: 'hello.zip', text: 'Hello Zip!'\n" +
-                        "  writeFile file: 'hello.txt', text: 'Hello world'\n" +
-                        "  zip zipFile: 'hello.zip', glob: '**/*.txt', archive: true, overwrite:true\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          writeFile file: 'hello.zip', text: 'Hello Zip!'
+                          writeFile file: 'hello.txt', text: 'Hello world'
+                          zip zipFile: 'hello.zip', glob: '**/*.txt', archive: true, overwrite:true
+                        }""",
+                true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0).get());
         j.assertLogNotContains("hello.zip exists.", run);
     }
 
     @Test
-    public void noExistingZipFileWithOverwrite() throws Exception {
+    void noExistingZipFileWithOverwrite() throws Exception {
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  writeFile file: 'hello.txt', text: 'Hello world'\n" +
-                        "  zip zipFile: 'hello.zip', glob: '**/*.txt', overwrite:true\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          writeFile file: 'hello.txt', text: 'Hello world'
+                          zip zipFile: 'hello.zip', glob: '**/*.txt', overwrite:true
+                        }""",
+                true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0).get());
         j.assertLogNotContains("java.io.IOException", run);
         j.assertLogNotContains("Failed to delete", run);
@@ -265,7 +284,7 @@ public class ZipStepTest {
     }
 
     private void verifyArchivedHello(WorkflowRun run, String basePath) throws IOException {
-        assertTrue("Build should have artifacts", run.getHasArtifacts());
+        assertTrue(run.getHasArtifacts(), "Build should have artifacts");
         Run<WorkflowJob, WorkflowRun>.Artifact artifact = run.getArtifacts().get(0);
         assertEquals("hello.zip", artifact.getFileName());
         VirtualFile file = run.getArtifactManager().root().child(artifact.relativePath);
@@ -279,38 +298,39 @@ public class ZipStepTest {
             try (Scanner scanner = new Scanner(zip)) {
                 assertTrue(scanner.hasNextLine());
                 assertEquals("Hello World!", scanner.nextLine());
-                assertNull("There should be no more entries", zip.getNextEntry());
+                assertNull(zip.getNextEntry(), "There should be no more entries");
             }
         }
     }
 
     private void verifyArchivedNotContainingItself(WorkflowRun run) throws IOException {
-        assertTrue("Build should have artifacts", run.getHasArtifacts());
+        assertTrue(run.getHasArtifacts(), "Build should have artifacts");
         Run<WorkflowJob, WorkflowRun>.Artifact artifact = run.getArtifacts().get(0);
         VirtualFile file = run.getArtifactManager().root().child(artifact.relativePath);
         try (ZipInputStream zip = new ZipInputStream(file.open())) {
             for (ZipEntry entry = zip.getNextEntry(); entry != null; entry = zip.getNextEntry()) {
-                assertNotEquals("The zip output file shouldn't contain itself", entry.getName(), artifact.relativePath);
+                assertNotEquals(entry.getName(), artifact.relativePath, "The zip output file shouldn't contain itself");
             }
         }
     }
 
     @Test
-    public void defaultExcludesPatternWithAll() throws Exception {
+    void defaultExcludesPatternWithAll() throws Exception {
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  writeFile file: '.gitignore', text: '/target'\n" +
-                        "  zip zipFile: 'hello.zip', defaultExcludes: false, archive: true\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          writeFile file: '.gitignore', text: '/target'
+                          zip zipFile: 'hello.zip', defaultExcludes: false, archive: true
+                        }""",
+                true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         verifyArchivedDefaultExcludes(run, "");
-
     }
 
     private void verifyArchivedDefaultExcludes(WorkflowRun run, String basePath) throws IOException {
-        assertTrue("Build should have artifacts", run.getHasArtifacts());
+        assertTrue(run.getHasArtifacts(), "Build should have artifacts");
         Run<WorkflowJob, WorkflowRun>.Artifact artifact = run.getArtifacts().get(0);
         assertEquals("hello.zip", artifact.getFileName());
         VirtualFile file = run.getArtifactManager().root().child(artifact.relativePath);
@@ -324,22 +344,23 @@ public class ZipStepTest {
             try (Scanner scanner = new Scanner(zip)) {
                 assertTrue(scanner.hasNextLine());
                 assertEquals("/target", scanner.nextLine());
-                assertNull("There should be no more entries", zip.getNextEntry());
+                assertNull(zip.getNextEntry(), "There should be no more entries");
             }
         }
     }
 
     @Test
-    public void defaultExcludesPatternEnabled() throws Exception {
+    void defaultExcludesPatternEnabled() throws Exception {
 
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "node('slaves') {\n" +
-                        "  writeFile file: '.gitignore', text: '/target'\n" +
-                        "  zip zipFile: 'hello.zip', defaultExcludes: true, archive: true\n" +
-                        "}", true));
+                """
+                        node('slaves') {
+                          writeFile file: '.gitignore', text: '/target'
+                          zip zipFile: 'hello.zip', defaultExcludes: true, archive: true
+                        }""",
+                true));
         WorkflowRun run = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         verifyArchivedNotContainingItself(run);
-
     }
 }


### PR DESCRIPTION
This PR aims to migrate all tests to JUnit5. Changes include:

* Migrate annotations and imports
* Migrate assertions
* Remove public visibility for test classes and methods
* Minor clean up

There is one exception where a migration was not possible as the tests rely on `Rule` implementations that have not (yet) been migrated to JUnit5:

* `TeeStepTest` using `JenkinsSessionRule` (in combination with `SemaphoreStep` -> see https://github.com/jenkinsci/jenkins-test-harness/pull/936)

I am well aware that this is a quite large changeset however I hope that there is still interest in this PR and it will be reviewed.
If there are any questions, please do not hesitate to ping me.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub 
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
