### PR TITLE
fix:link correction in pipeline utility steps page

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStep/help.html
@@ -23,7 +23,7 @@
   -->
 <p>
     Writes yaml to a file in the current working directory or a String from an Object or a String.
-    It uses <a href="https://bitbucket.org/asomov/snakeyaml" target="_blank">SnakeYAML</a> as YAML processor.
+    It uses <a href="https://bitbucket.org/snakeyaml/snakeyaml" target="_blank">SnakeYAML</a> as YAML processor.
     The call will fail if the file already exists.
 </p>
 <strong>Fields:</strong>


### PR DESCRIPTION
This PR fixes the outdated link available in the pipeline utility step pages .
