### PR TITLE
Add MD5 hash step support

### DIFF
--- a/docs/STEPS.md
+++ b/docs/STEPS.md
@@ -6,8 +6,10 @@
 * `touch` - Create a file (if not already exist) in the workspace, and set the timestamp. Returns a [FileWrapper](../src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileWrapper.java) representing the file that was touched. ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/TouchStep/help.html))
 * `sha1` - Computes the SHA1 of a given file. ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha1Step/help.html))
 * `sha256` - Computes the SHA-256 of a given file. ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileSha256Step/help.html))
+* `md5` - Computes the MD5 of a given file. ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileMd5Step/help.html))
 * `verifySha1` - Verifies the SHA-1 of a given file. ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileVerifySha1Step/help.html))
 * `verifySha256` - Verifies the SHA-256 of a given file. ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileVerifySha256Step/help.html))
+* `verifyMd5` - Verifies the MD5 of a given file. ([help](../src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileVerifyMd5Step/help.html))
 * `tee` - Tee output to file
 
 ### Tar/tar.gz/tgz Files

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileMd5Step.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileMd5Step.java
@@ -1,0 +1,22 @@
+package org.jenkinsci.plugins.pipeline.utility.steps.fs;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Compute the MD5 of a file.
+ */
+public class FileMd5Step extends FileHashStep {
+    @DataBoundConstructor
+    public FileMd5Step(String file) throws Descriptor.FormException {
+        super(file, "MD5");
+    }
+
+    @Extension
+    public static class DescriptorImpl extends FileHashStep.DescriptorImpl {
+        public DescriptorImpl() {
+            super("MD5");
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileVerifyMd5Step.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileVerifyMd5Step.java
@@ -1,0 +1,22 @@
+package org.jenkinsci.plugins.pipeline.utility.steps.fs;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Verify the MD5 of a file.
+ */
+public class FileVerifyMd5Step extends FileVerifyHashStep {
+    @DataBoundConstructor
+    public FileVerifyMd5Step(String file, String hash) throws Descriptor.FormException {
+        super(file, hash, "MD5");
+    }
+
+    @Extension
+    public static class DescriptorImpl extends FileVerifyHashStep.DescriptorImpl {
+        public DescriptorImpl() {
+            super("Md5");
+        }
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileMd5Step/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileMd5Step/config.groovy
@@ -1,0 +1,9 @@
+package org.jenkinsci.plugins.pipeline.utility.steps.fs.FileMd5Step
+
+import lib.FormTagLib
+
+def f = namespace(FormTagLib) as FormTagLib
+
+f.entry(field: 'file', title: _('File')) {
+    f.textbox()
+}

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileMd5Step/help-file.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileMd5Step/help-file.html
@@ -1,0 +1,1 @@
+<p>The path to the file to hash.</p>

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileMd5Step/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileMd5Step/help.html
@@ -1,0 +1,1 @@
+<p>Computes the MD5 of a given file.</p>

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileVerifyMd5Step/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileVerifyMd5Step/config.groovy
@@ -1,0 +1,13 @@
+package org.jenkinsci.plugins.pipeline.utility.steps.fs.FileVerifyMd5Step
+
+import lib.FormTagLib
+
+def f = namespace(FormTagLib) as FormTagLib
+
+f.entry(field: 'file', title: _('File')) {
+    f.textbox()
+}
+
+f.entry(field: 'hash', title: _('Hash')) {
+    f.textbox()
+}

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileVerifyMd5Step/help-file.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileVerifyMd5Step/help-file.html
@@ -1,0 +1,1 @@
+<p>The path to the file to hash.</p>

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileVerifyMd5Step/help-hash.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileVerifyMd5Step/help-hash.html
@@ -1,0 +1,1 @@
+<p>The expected hash.</p>

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileVerifyMd5Step/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileVerifyMd5Step/help.html
@@ -1,0 +1,1 @@
+<p>Verifies the MD5 of a given file.</p>

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileMd5StepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileMd5StepTest.java
@@ -1,0 +1,77 @@
+package org.jenkinsci.plugins.pipeline.utility.steps.fs;
+
+import hudson.model.Label;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class FileMd5StepTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Before
+    public void setup() throws Exception {
+        j.createOnlineSlave(Label.get("remote"));
+    }
+
+    @Test
+    public void configRoundTrip() throws Exception {
+        FileMd5Step step = new FileMd5Step("dir/f.txt");
+        FileMd5Step step2 = new StepConfigTester(j).configRoundTrip(step);
+        j.assertEqualDataBoundBeans(step, step2);
+    }
+
+    @Test
+    public void emptyFile() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                """
+                  node('remote') {
+                    dir('test') {
+                      touch 'empty.txt'
+                      def hash = md5 'empty.txt'
+                      assert hash == 'd41d8cd98f00b204e9800998ecf8427e'
+                    }
+                  }
+                """,
+                true));
+        j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    }
+
+    @Test
+    public void fileWithContent() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                """
+                  node('remote') {
+                    dir('test') {
+                      writeFile file: 'f.txt', text: 'abc', encoding: 'UTF-8'
+                      def hash = md5 'f.txt'
+                      assert hash == '900150983cd24fb0d6963f7d28e17f72'
+                    }
+                  }
+                """,
+                true));
+        j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    }
+
+    @Test
+    public void returnsNullIfFileNotFound() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                """
+                   node('remote') {
+                     dir('test') {
+                       def hash = md5 'not_existing.txt'
+                       assert hash == null
+                     }
+                   }
+                """,
+                true));
+        j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileMd5VerifyStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileMd5VerifyStepTest.java
@@ -1,0 +1,110 @@
+package org.jenkinsci.plugins.pipeline.utility.steps.fs;
+
+import hudson.model.Label;
+import hudson.model.Result;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class FileMd5VerifyStepTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Before
+    public void setup() throws Exception {
+        j.createOnlineSlave(Label.get("remote"));
+    }
+
+    @Test
+    public void configRoundTrip() throws Exception {
+        FileVerifyMd5Step step = new FileVerifyMd5Step("f.txt", "hash");
+        FileVerifyMd5Step step2 = new StepConfigTester(j).configRoundTrip(step);
+        j.assertEqualDataBoundBeans(step, step2);
+    }
+
+    @Test
+    public void emptyFile() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                """
+                  node('remote') {
+                    dir('test') {
+                      touch 'empty.txt'
+                      verifyMd5(file: 'empty.txt', hash: 'd41d8cd98f00b204e9800998ecf8427e')
+                    }
+                  }
+                """,
+                true));
+        j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    }
+
+    @Test
+    public void ignoresHashCase() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                """
+                  node('remote') {
+                    dir('test') {
+                     touch 'empty.txt'
+                     verifyMd5(file: 'empty.txt', hash: 'D41D8CD98F00B204E9800998ECF8427E')
+                    }
+                  }
+                """,
+                true));
+        j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    }
+
+    @Test
+    public void fileWithContent() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                """
+                  node('remote') {
+                    dir('test') {
+                      writeFile file: 'f.txt', text: 'abc', encoding: 'UTF-8'
+                      verifyMd5(file: 'f.txt', hash: '900150983cd24fb0d6963f7d28e17f72')
+                    }
+                  }
+                """,
+                true));
+        j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    }
+
+    @Test
+    public void failsOnMismatch() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                """
+                  node('remote') {
+                    dir('test') {
+                      writeFile file: 'fail.txt', text: 'should fail with invalid hash', encoding: 'UTF-8'
+                      verifyMd5(file: 'fail.txt', hash: '900150983cd24fb0d6963f7d28e17f72')
+                    }
+                  }
+                """,
+                true));
+        final WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
+        j.assertLogContains("MD5 hash mismatch", run);
+    }
+
+    @Test
+    public void failsIfFileNotFound() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                """
+                  node('remote') {
+                    dir('test') {
+                    verifyMd5(file: 'nonexistent.txt', hash: 'd41d8cd98f00b204e9800998ecf8427e')
+                  }
+                }
+                """,
+                true));
+        final WorkflowRun run = j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
+        j.assertLogContains("File not found: nonexistent.txt", run);
+    }
+}


### PR DESCRIPTION
This PR adds MD5 hash generation and verification steps, similar to the existing SHA1 and SHA256 steps. 
This addresses [JENKINS-75066](https://issues.jenkins.io/browse/JENKINS-75066)

### Testing done
- added test cases covering common scenarios.
- deployed this change to my local instance and tested with various file types and scenarios.

Example pipeline:
```groovy
node {
    stage('Generate and Verify MD5') {
        writeFile(file: "test.txt", text: "test content", encoding: "UTF-8")
        
        def fileMd5 = md5(file: 'test.txt')
        echo "MD5: ${fileMd5}"
        
        verifyMd5(file: 'test.txt', hash: fileMd5)
    }
}
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
