### PR TITLE
Ban JUnit 4 imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.24</version>
+        <version>5.26</version>
         <relativePath />
     </parent>
     <artifactId>pipeline-utility-steps</artifactId>
@@ -66,6 +66,7 @@
         <spotbugs.effort>Max</spotbugs.effort>
         <spotbugs.failOnError>true</spotbugs.failOnError>
         <spotbugs.threshold>Medium</spotbugs.threshold>
+        <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
 

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadYamlStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadYamlStepTest.java
@@ -1,7 +1,9 @@
 package org.jenkinsci.plugins.pipeline.utility.steps.conf;
 
 import static org.jenkinsci.plugins.pipeline.utility.steps.FilenameTestsUtils.separatorsToSystemEscaped;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import hudson.model.Label;
 import hudson.model.Result;
@@ -224,8 +226,7 @@ class ReadYamlStepTest {
     @Test
     void setDefaultCodePointLimitHigherThanMaxFailsWithException() {
         Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            ReadYamlStep readYamlStep = new ReadYamlStep();
-            readYamlStep.setDefaultCodePointLimit(ReadYamlStep.getMaxCodePointLimit() + 1);
+            ReadYamlStep.setDefaultCodePointLimit(ReadYamlStep.getMaxCodePointLimit() + 1);
         });
         String expectedMessage =
                 "Reduce the required DEFAULT_CODE_POINT_LIMIT or convince your administrator to increase";
@@ -275,8 +276,7 @@ class ReadYamlStepTest {
     @Test
     void setDefaultHigherThanMaxFailsWithException() {
         Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            ReadYamlStep readYamlStep = new ReadYamlStep();
-            readYamlStep.setDefaultMaxAliasesForCollections(ReadYamlStep.getMaxMaxAliasesForCollections() + 1);
+            ReadYamlStep.setDefaultMaxAliasesForCollections(ReadYamlStep.getMaxMaxAliasesForCollections() + 1);
         });
         String expectedMessage =
                 "Reduce the required DEFAULT_MAX_ALIASES_FOR_COLLECTIONS or convince your administrator to increase";
@@ -289,8 +289,7 @@ class ReadYamlStepTest {
     @Test
     void setDefaultHigherThanHardcodedMaxFailsWithException() {
         Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            ReadYamlStep readYamlStep = new ReadYamlStep();
-            readYamlStep.setDefaultMaxAliasesForCollections(
+            ReadYamlStep.setDefaultMaxAliasesForCollections(
                     ReadYamlStep.HARDCODED_CEILING_MAX_ALIASES_FOR_COLLECTIONS + 1);
         });
         String expectedMessage = "Hardcoded upper limit breached";

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStepUnitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/WriteYamlStepUnitTest.java
@@ -31,10 +31,10 @@ class WriteYamlStepUnitTest {
 
     @Test
     void writeInvalidDocuments() {
-        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> {
-            WriteYamlStep writeStep = new WriteYamlStep("/dev/null");
-            writeStep.setDatas(new ArrayList<>(Collections.singletonList(new Yaml())));
-        });
+        WriteYamlStep writeStep = new WriteYamlStep("/dev/null");
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () ->
+                writeStep.setDatas(new ArrayList<>(Collections.singletonList(new Yaml())))
+        );
         assertThat(thrown.getMessage(), equalTo("datas parameter has invalid content (no-basic classes)"));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/TeeStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/TeeStepTest.java
@@ -36,24 +36,24 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.jvnet.hudson.test.BuildWatcher;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.JenkinsSessionRule;
+import org.jvnet.hudson.test.junit.jupiter.BuildWatcherExtension;
+import org.jvnet.hudson.test.junit.jupiter.JenkinsSessionExtension;
 
-public class TeeStepTest {
+class TeeStepTest {
 
-    @ClassRule
-    public static BuildWatcher buildWatcher = new BuildWatcher();
+    @SuppressWarnings("unused")
+    @RegisterExtension
+    private static final BuildWatcherExtension BUILD_WATCHER = new BuildWatcherExtension();
 
-    @Rule
-    public JenkinsSessionRule sessions = new JenkinsSessionRule();
+    @RegisterExtension
+    private final JenkinsSessionExtension sessions = new JenkinsSessionExtension();
 
     @Test
-    public void smokes() throws Throwable {
+    void smokes() throws Throwable {
         sessions.then(r -> {
             r.createSlave("remote", null, null);
             WorkflowJob p = r.createProject(WorkflowJob.class, "p");
@@ -90,7 +90,7 @@ public class TeeStepTest {
 
     @Test
     @Issue({"JENKINS-54346", "JENKINS-55505"})
-    public void closed() throws Throwable {
+    void closed() throws Throwable {
         sessions.then(r -> {
             r.createSlave("remote", null, null);
             WorkflowJob p = r.createProject(WorkflowJob.class, "p");
@@ -113,7 +113,7 @@ public class TeeStepTest {
 
     @Test
     @Issue({"JENKINS-55505"})
-    public void closedMultiple() throws Throwable {
+    void closedMultiple() throws Throwable {
         sessions.then(r -> {
             r.createSlave("remote", null, null);
             WorkflowJob p = r.createProject(WorkflowJob.class, "p");
@@ -143,7 +143,7 @@ public class TeeStepTest {
     }
 
     @Test
-    public void configRoundtrip() throws Throwable {
+    void configRoundtrip() throws Throwable {
         sessions.then(r -> {
             TeeStep s = new TeeStep("x.log");
             StepConfigTester t = new StepConfigTester(r);


### PR DESCRIPTION
### Ban JUnit 4 imports

To prevent regressions when adding new tests, https://github.com/jenkinsci/plugin-pom/pull/1178 introduced a new flag that enables a Maven Enforcer rule banning `org.junit.*` imports while allowing `org.junit.jupiter.*`.

With this change, the build will fail if any `org.junit.*` imports are introduced.

My migration tool also proposed some minor fixes I included in this PR.

### Testing done

None. Rely on `ci.jenkins.io`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
