### PR TITLE
Skip CloudBees CI HA agent clones in `nodesByLabel` step

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/jenkins/NodesByLabelStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/jenkins/NodesByLabelStep.java
@@ -135,6 +135,10 @@ public class NodesByLabelStep extends Step {
             List<String> nodes = new ArrayList<>();
             if (nodeSet != null && !nodeSet.isEmpty()) {
                 for (Node node : nodeSet) {
+                    if (node.getClass().getName().equals("com.cloudbees.jenkins.plugins.replication.agents.MultipleExecutorsProperty$ExtraSlaveNode")) {
+                        logger.println("Skipping CloudBees CI HA agent clone: " + node.getNodeName());
+                        continue;
+                    }
                     Computer computer = node.toComputer();
                     if (!includeOffline && (computer == null || computer.isOffline())) {
                         continue;

--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/jenkins/NodesByLabelStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/jenkins/NodesByLabelStep.java
@@ -135,7 +135,7 @@ public class NodesByLabelStep extends Step {
             List<String> nodes = new ArrayList<>();
             if (nodeSet != null && !nodeSet.isEmpty()) {
                 for (Node node : nodeSet) {
-                    if (node.getClass().getName().equals("com.cloudbees.jenkins.plugins.replication.agents.MultipleExecutorsProperty$ExtraSlaveNode")) {
+                    if (node.getClass().getName().equals("com.cloudbees.jenkins.plugins.replication.agents.MultipleExecutorsProperty$ExtraSlave")) {
                         logger.println("Skipping CloudBees CI HA agent clone: " + node.getNodeName());
                         continue;
                     }


### PR DESCRIPTION
CloudBees CI in high availability mode includes the ability to automatically manage clones of permanent agents which are used almost transparently like the originals. For purposes of the `nodesByLabel` step it is undesirable to list them, since they are considered equivalent to executors of the same agent.

Functional test in proprietary code.