### PR TITLE
Retain original entry order in Map returned by readProperties

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepExecution.java
@@ -45,6 +45,7 @@ import java.io.StringReader;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
 
@@ -76,10 +77,23 @@ public class ReadPropertiesStepExecution extends AbstractFileOrTextStepExecution
     @Override
     protected Map<String, Object> doRun() throws Exception {
         PrintStream logger = getLogger();
-        Properties properties = new Properties();
+        Map<String, Object> result = new LinkedHashMap<>(); // Retains original order
+        Properties properties = new Properties() {
+            @Override
+            public synchronized void putAll(Map<?, ?> m) {
+                m.forEach(this::put);
+                super.putAll(m);
+            }
+
+            @Override
+            public synchronized Object put(Object key, Object value) {
+                 result.put(key != null ? key.toString() : null, value);
+                 return super.put(key, value);
+            }
+        };
 
         if (step.getDefaults() != null) {
-        	properties.putAll(step.getDefaults());
+            properties.putAll(step.getDefaults());
         }
 
         if (!StringUtils.isBlank(step.getFile())) {
@@ -113,28 +127,10 @@ public class ReadPropertiesStepExecution extends AbstractFileOrTextStepExecution
         // Check if we should interpolated values in the properties
         if ( step.isInterpolate() ) {
             logger.println("Interpolation set to true, starting to parse the variable!");
-            properties = interpolateProperties(properties);
+            Properties interpolatedProperties = interpolateProperties(properties);
+            result.replaceAll((key, value) -> interpolatedProperties.getOrDefault(key, value));
         }
-
-        Map<String, Object> result = new HashMap<>();
-        addAll(properties, result);
         return result;
-    }
-
-    /**
-     * addAll implementation that will coerce keys into Strings.
-     *
-     * @param src the source
-     * @param dst the destination
-     */
-    private void addAll(Map<Object, Object> src, Map<String, Object> dst) {
-        if (src == null) {
-            return;
-        }
-
-        for (Map.Entry<Object, Object> e : src.entrySet()) {
-            dst.put(e.getKey() != null ? e.getKey().toString(): null, e.getValue());
-        }
     }
 
     /**
@@ -143,8 +139,6 @@ public class ReadPropertiesStepExecution extends AbstractFileOrTextStepExecution
      * @return a new Properties object with the interpolated values
      */
     private Properties interpolateProperties(Properties properties) throws Exception {
-        if ( properties == null)
-            return null;
         PrintStream logger = getLogger();
         try {
             ConfigurationInterpolator configurationInterpolator = ConfigurationInterpolator.fromSpecification(

--- a/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/utility/steps/conf/ReadPropertiesStepTest.java
@@ -35,6 +35,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Properties;
 import org.jenkinsci.plugins.pipeline.utility.steps.Messages;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
@@ -87,19 +88,23 @@ class ReadPropertiesStepTest {
         props.setProperty("test", "One");
         props.setProperty("another", "Two");
         File file = File.createTempFile("junit", null, temp);
-        try (FileWriter f = new FileWriter(file)) {
-            props.store(f, "Pipeline test");
-        }
-
+        Files.writeString(file.toPath(), """
+                test = One
+                another = Two
+                aThird = Three
+                """);
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
                 "node('slaves') {\n" + "  def props = readProperties file: '"
-                        + separatorsToSystemEscaped(file.getAbsolutePath()) + "'\n"
-                        + "  assert props['test'] == 'One'\n"
-                        + "  assert props['another'] == 'Two'\n"
-                        + "  assert props.test == 'One'\n"
-                        + "  assert props.another == 'Two'\n"
-                        + "}",
+                        + separatorsToSystemEscaped(file.getAbsolutePath()) + "'" + """
+
+                                    assert props['test'] == 'One'
+                                    assert props['another'] == 'Two'
+                                    assert props.test == 'One'
+                                    assert props.another == 'Two'
+                                    assert props.keySet().toList() == [ 'test', 'another', 'aThird' ]
+                                }
+                                """,
                 true));
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }


### PR DESCRIPTION
Enhance the `readProperties` step retain original entry order in the returned `Map`.
The `Properties` class does not do that by default, still it can be nice to have in some cases.

### Testing done

Ran the change in a local Jenkins instance using `hpi:run -Pjenkins` and created a simple pipeline that read a properties file and verified the result maintains the original order.
Furthermore extended the existing test case to also verify the entry order.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
